### PR TITLE
fix: panel and dropdown overlap

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -249,7 +249,7 @@
 
 .draggable-panel-css {
     border-radius: 5px;
-    z-index: 100;
+    z-index: 70;
     transition: background 0.5s ease-out;
     position: fixed;
 }

--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -769,8 +769,8 @@ function setupPanelListeners(panelSelector) {
     )
     // Current Panel on Top
     $(panelSelector).on('mousedown', () => {
-        $(`.draggable-panel:not(${panelSelector})`).css('z-index', '99')
-        $(panelSelector).css('z-index', '100')
+        $(`.draggable-panel:not(${panelSelector})`).css('z-index', '70')
+        $(panelSelector).css('z-index', '71')
     })
     var minimized = false
     $(headerSelector).on('dblclick', () =>

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -322,7 +322,7 @@ input[type='text']:focus {
 
 .draggable-panel-css {
     border-radius: 5px;
-    z-index: 100;
+    z-index: 70;
     transition: background 0.5s ease-out;
     position: fixed;
 }
@@ -737,7 +737,7 @@ div.icon img {
 
 .timing-diagram-panel {
     border-radius: 5px;
-    z-index: 100;
+    z-index: 70;
     transition: background 0.5s ease-out;
     position: fixed;
     cursor: pointer;


### PR DESCRIPTION
- > **The panels and dropdowns no longer overlaps with each other**.

Fixes: #43

#### Describe the changes you have made in this PR -

- Changed the z-index of multiple elements to prevent overlapping.

### Screenshots of the changes (If any) -
![Screenshot from 2023-01-05 07-07-47](https://user-images.githubusercontent.com/66828942/210682030-81425fc9-993d-401e-9e2c-2da96001f1a4.png)

### Demo Video-
https://user-images.githubusercontent.com/66828942/210682010-aeb6027c-237f-4c96-9dd9-52d2c9254143.mp4



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 