### PR TITLE
fix: remove svgloader and fixed the themes dialog box not showing

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
         "esbuild": "^0.14.45",
         "jquery": "^3.6.0",
         "pinia": "^2.0.14",
-        "vite-svg-loader": "^3.4.0",
         "vue": "^3.2.25",
         "vue-i18n": "^9.1.10",
         "vue-router": "^4.0.15",
@@ -47,7 +46,6 @@
         "vite": "^2.9.13",
         "vite-plugin-vuetify": "^1.0.0-alpha.0",
         "vue-cli-plugin-vuetify": "~2.5.1",
-        "vue-svg-loader": "^0.16.0",
         "vue-tsc": "^0.34.7"
     }
 }

--- a/src/components/DialogBox/Themes/ApplyThemes.vue
+++ b/src/components/DialogBox/Themes/ApplyThemes.vue
@@ -35,14 +35,36 @@
                                 @click="changeTheme($event)"
                             ></div>
                             <span>
-                                <DefaultTheme v-if="theme == 'Default Theme'" />
-                                <NightSky v-if="theme == 'Night Sky'" />
-                                <LitebornSpring
-                                    v-if="theme == 'Lite-born Spring'"
+                                <img
+                                    v-if="theme == 'Default Theme'"
+                                    src="../../../assets/themes/DefaultTheme.svg"
+                                    style="display: block"
                                 />
-                                <GnW v-if="theme == 'G&W'" />
-                                <HighContrast v-if="theme == 'High Contrast'" />
-                                <ColorBlind v-if="theme == 'Color Blind'" />
+                                <img
+                                    v-if="theme == 'Night Sky'"
+                                    src="../../../assets/themes/NightSky.svg"
+                                    style="display: block"
+                                />
+                                <img
+                                    v-if="theme == 'Lite-born Spring'"
+                                    src="../../../assets/themes/LitebornSpring.svg"
+                                    style="display: block"
+                                />
+                                <img
+                                    v-if="theme == 'G&W'"
+                                    src="../../../assets/themes/GnW.svg"
+                                    style="display: block"
+                                />
+                                <img
+                                    v-if="theme == 'High Contrast'"
+                                    src="../../../assets/themes/HighContrast.svg"
+                                    style="display: block"
+                                />
+                                <img
+                                    v-if="theme == 'Color Blind'"
+                                    src="../../../assets/themes/ColorBlind.svg"
+                                    style="display: block"
+                                />
                             </span>
                             <span id="themeNameBox" class="themeNameBox">
                                 <input
@@ -130,12 +152,6 @@ import {
     updateThemeForStyle,
 } from '#/simulator/src/themer/themer'
 const SimulatorState = useState()
-import DefaultTheme from '#/assets/themes/DefaultTheme.svg'
-import NightSky from '#/assets/themes/NightSky.svg'
-import LitebornSpring from '#/assets/themes/LitebornSpring.svg'
-import GnW from '#/assets/themes/GnW.svg'
-import HighContrast from '#/assets/themes/HighContrast.svg'
-import ColorBlind from '#/assets/themes/ColorBlind.svg'
 import { CreateAbstraction } from '#/simulator/src/themer/customThemeAbstraction'
 const themes = ref([''])
 const customThemes = ref([''])

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { fileURLToPath, URL } from 'url'
 import vueI18n from '@intlify/vite-plugin-vue-i18n'
-import svgLoader from 'vite-svg-loader'
 
 // https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
 import vuetify from 'vite-plugin-vuetify'
@@ -21,7 +20,6 @@ export default defineConfig({
                 new URL('./src/locales/**', import.meta.url)
             ),
         }),
-        svgLoader(),
     ],
     resolve: {
         alias: {


### PR DESCRIPTION
Fixes #50 

#### Describe the changes you have made in this PR -
`svgLoader` package which enable us to use SVGs as component.
> was used in the themes dialog box to show theme cards
was blocking the SVG loads of circuit elements in the production.

solve: removed the package.
and in the `themes-dialog box` the `theme cards` are displayed as images.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 