### PR TITLE
draft PR: search functionality in custom shortcuts panel

### DIFF
--- a/src/components/DialogBox/CustomShortcut.vue
+++ b/src/components/DialogBox/CustomShortcut.vue
@@ -14,7 +14,8 @@
                 >
                     <v-icon>mdi-close</v-icon>
                 </v-btn>
-                <div id="customShortcutDialog" title="Keybinding Preference">
+                <v-text-field label="Search Command" v-model="search"></v-text-field>
+                <div v-if="search && searchCommand().length" id="customShortcutDialog" title="Keybinding Preference">
                     <!-- Edit Panel -->
                     <div id="edit" tabindex="0" @keydown="updateEdit($event)">
                         <span style="font-size: 14px">
@@ -37,13 +38,47 @@
                     >
                         <!-- Elements -->
                         <div
-                            v-for="(keyOption, index) in keyOptions"
+                            v-for="(keyOption, index) in searchCommand()"
                             :key="index"
                         >
                             <span id="edit-icon"></span>
                             <div>
                                 <span id="command">{{ keyOption[0] }}</span>
-                                <span id="keyword"></span>
+                                <span id="keyword">{{keyOption[1]}}</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div v-if="!search" id="customShortcutDialog" title="Keybinding Preference">
+                    <!-- Edit Panel -->
+                    <div id="edit" tabindex="0" @keydown="updateEdit($event)">
+                        <span style="font-size: 14px">
+                            Press Desire Key Combination & press Enter or press
+                            ESC to cancel.
+                        </span>
+                        <div id="pressedKeys"></div>
+                        <div id="warning"></div>
+                    </div>
+                    <!-- Heading -->
+                    <div id="heading">
+                        <span>Command</span>
+                        <span>Keymapping</span>
+                    </div>
+                    <!-- Markup -->
+                    <div
+                      id="preference"
+                      class="customScroll"
+                      @click="updatePreference($event)"
+                    >
+                        <!-- Elements -->
+                        <div
+                          v-for="(keyOption, index) in keyOptions"
+                          :key="index"
+                        >
+                            <span id="edit-icon"></span>
+                            <div>
+                                <span id="command">{{ keyOption[0] }}</span>
+                                <span id="keyword">{{keyOption[1]}}</span>
                             </div>
                         </div>
                     </div>
@@ -82,6 +117,8 @@ import { onMounted, onUpdated, ref } from '@vue/runtime-core'
 const SimulatorState = useState()
 const keyOptions = ref([])
 const targetPref = ref(null)
+const search = ref('');
+
 
 onMounted(() => {
     SimulatorState.dialogBox.customshortcut_dialog = false
@@ -95,6 +132,13 @@ onUpdated(() => {
     } else setDefault()
 })
 
+const searchCommand=()=>{
+    if(!search.value) return [];
+    const searchResult = keyOptions.value.filter((target)=>{
+         return target[0].toLowerCase().includes(search.value.toLowerCase());
+    })
+    return searchResult;
+}
 function updatePreference(e) {
     $('#pressedKeys').text('')
     $('#warning').text('')
@@ -154,11 +198,11 @@ function updateEdit(e) {
         $('#pressedKeys').text(currentKey)
     }
     if (
-        ($('#pressedKeys').text().split(' + ').length === 2 &&
+         ($('#pressedKeys').text().split(' + ').length === 2 &&
             ['Ctrl', 'Meta'].includes(
-                $('#pressedKeys').text().split(' + ')[1]
+              $('#pressedKeys').text().split(' + ')[1]
             )) ||
-        ($('#pressedKeys').text().split(' + ')[0] === 'Alt' &&
+         ($('#pressedKeys').text().split(' + ')[0] === 'Alt' &&
             $('#pressedKeys').text().split(' + ')[1] === 'Shift')
     ) {
         $('#pressedKeys').text(

--- a/src/styles/css/shortcut.panel.css
+++ b/src/styles/css/shortcut.panel.css
@@ -40,6 +40,7 @@
 }
 
 #customShortcutDialog {
+    width: 600px;
     align-items: center;
     color: white;
     flex-direction: column;


### PR DESCRIPTION
Fixes #48 

**Changes:**

- a search bar in the custom shortcut panel.

**Demo Video:**
![circuitverse_draft_pr](https://user-images.githubusercontent.com/66828942/211127582-399c9146-8dea-407b-8b50-eecf70e6db64.gif)

**Problem:**

- Currently to check whether the given custom input is  assigned to something  is a procedure where, inside `customShortcuts.vue` a function 
` warnOverride($('#pressedKeys').text(), targetPref.value)` is called where `targetPref` send something like this:

![Screenshot from 2023-01-07 08-01-28](https://user-images.githubusercontent.com/66828942/211127793-3dbe17e8-431a-40f8-8914-2b917631f7bd.png)

- after this inside `actions.js` file a function is called [ref](https://github.com/CircuitVerse/cv-frontend-vue/blob/043093ba49fd9224e6d195d4d4289bb4504cc7ec/src/simulator/src/hotkey_binder/model/actions.js#L110), which iterate through all the present children of div and match whether it has been assigned already or not.
- with the new changes if you search something then the number of shortcuts will reduce on the screen which reduces the child div;s because of this:

- **if you try to assign a shortcut that has already been assigned to something else( which is not shown on the screen) then it won't warn and just assign that shortcut to the given command.** 

> I was wondering if there could be a way to implement this feature of checking the assigned shortcuts differently instead of children div's then this search functionality could work much better.

cc: @devartstar @tachyons 


