### PR TITLE
add: Pencil icon on hover in custom shortcut panel.

### DIFF
--- a/src/components/DialogBox/CustomShortcut.vue
+++ b/src/components/DialogBox/CustomShortcut.vue
@@ -40,7 +40,7 @@
                             v-for="(keyOption, index) in keyOptions"
                             :key="index"
                         >
-                            <span id="edit-icon"></span>
+                            <span id="edit-icon"><v-icon>small mdi-pencil-outline</v-icon></span>
                             <div>
                                 <span id="command">{{ keyOption[0] }}</span>
                                 <span id="keyword"></span>


### PR DESCRIPTION
Added a pencil-outline icon on hover in custom shortcuts panel.
Fixes: #54

#### Describe the changes you have made in this PR -

- added a pencil-outline icon

### Screenshots of the changes (If any) -

![circuitverse](https://user-images.githubusercontent.com/66828942/211156692-b935d18c-c315-496c-8818-50380ca76dbf.gif)


