### PR TITLE
fix: exit preview button error

### DIFF
--- a/src/components/Navbar/QuickButton/QuickButton.vue
+++ b/src/components/Navbar/QuickButton/QuickButton.vue
@@ -178,39 +178,47 @@
         </div>
     </div>
 </template>
-<script lang="js">
+<script lang="ts" scoped>
 export default {
     methods: {
+        fullView() {
+            const exitViewBtn = document.createElement('button');
+            exitViewBtn.id = 'exitViewBtn';
+            exitViewBtn.textContent = 'Exit Full Preview';
+            exitViewBtn.addEventListener('click', this.exitFullView);
 
-        exitFullView() {
-        $('.navbar').show()
-        $('.modules').show()
-        $('.report-sidebar').show()
-        $('#tabsBar').show()
-        $('#exitViewBtn').remove()
-        $('#moduleProperty').show()
-        $('.timing-diagram-panel').show()
-        $('.testbench-manual-panel').show()
-        $('.quick-btn').show()
+            const app = document.getElementById('app');
+            if (app) {
+                app.appendChild(exitViewBtn);
+            }
+
+            const elements = document.querySelectorAll('.navbar, .modules, .report-sidebar, .timing-diagram-panel, .testbench-manual-panel, .quick-btn, #tabsBar, #moduleProperty');
+
+            elements.forEach(el => {
+                if (el instanceof HTMLElement) {
+                    el.style.display = 'none';
+                }
+            });
         },
 
-        fullView() {
-            const markUp = `<button id='exitViewBtn' >Exit Full Preview</button>`
-            $('.navbar').hide()
-            $('.modules').hide()
-            $('.report-sidebar').hide()
-            $('#tabsBar').hide()
-            $('#moduleProperty').hide()
-            $('.timing-diagram-panel').hide()
-            $('.testbench-manual-panel').hide()
-            $('.quick-btn').hide()
-            $('#app').append(markUp)
+    exitFullView() {
+        const exitViewBtn = document.getElementById('exitViewBtn');
+        if (exitViewBtn) {
+            exitViewBtn.remove();
         }
-    }
-}
+
+            const elements = document.querySelectorAll('.navbar, .modules, .report-sidebar, .timing-diagram-panel, .testbench-manual-panel, .quick-btn, #tabsBar, #moduleProperty');
+
+            elements.forEach(el => {
+                if (el instanceof HTMLElement) {
+                    el.style.display = '';
+                }
+            });
+        }
+     
+    },
+};
 </script>
-
-
 <style scoped>
 /* @import url('./QuickButton.css'); */
 </style>

--- a/src/components/Navbar/QuickButton/QuickButton.vue
+++ b/src/components/Navbar/QuickButton/QuickButton.vue
@@ -155,6 +155,7 @@
         <div>
             <button
                 id="viewButton"
+                @click="fullView"
                 type="button"
                 class="quick-btn-view"
                 title="Preview Circuit"
@@ -177,8 +178,38 @@
         </div>
     </div>
 </template>
+<script lang="js">
+export default {
+    methods: {
 
-<script lang="ts" setup></script>
+        exitFullView() {
+        $('.navbar').show()
+        $('.modules').show()
+        $('.report-sidebar').show()
+        $('#tabsBar').show()
+        $('#exitViewBtn').remove()
+        $('#moduleProperty').show()
+        $('.timing-diagram-panel').show()
+        $('.testbench-manual-panel').show()
+        $('.quick-btn').show()
+        },
+
+        fullView() {
+            const markUp = `<button id='exitViewBtn' >Exit Full Preview</button>`
+            $('.navbar').hide()
+            $('.modules').hide()
+            $('.report-sidebar').hide()
+            $('#tabsBar').hide()
+            $('#moduleProperty').hide()
+            $('.timing-diagram-panel').hide()
+            $('.testbench-manual-panel').hide()
+            $('.quick-btn').hide()
+            $('#app').append(markUp)
+        }
+    }
+}
+</script>
+
 
 <style scoped>
 /* @import url('./QuickButton.css'); */

--- a/src/simulator/src/data.js
+++ b/src/simulator/src/data.js
@@ -1,4 +1,6 @@
-import { fullView, deleteSelected } from './ux'
+import { deleteSelected } from './ux'
+import components from '@/Navbar/QuickButton/QuickButton.vue'
+const fullView = components.methods.fullView
 import { createSubCircuitPrompt } from './subcircuit'
 import save from './data/save'
 import load from './data/load'

--- a/src/simulator/src/listeners.js
+++ b/src/simulator/src/listeners.js
@@ -17,14 +17,16 @@ import {
     gridUpdateSet,
     errorDetectedSet,
 } from './engine'
+
+import components from'@/Navbar/QuickButton/QuickButton.vue'
+const exitFullView = components.methods.exitFullView;
+
 import { changeScale } from './canvasApi'
 import { scheduleBackup } from './data/backupCircuit'
 import {
     hideProperties,
     deleteSelected,
     uxvar,
-    fullView,
-    exitFullView,
 } from './ux'
 import {
     updateRestrictedElementsList,
@@ -62,9 +64,14 @@ export default function startListeners() {
     $('#redoButton').on('click', () => {
         redo()
     })
-    $('#viewButton').on('click', () => {
-        fullView()
+
+    $(document).on('click','#exitViewBtn', () => {
+        exitFullView();
     })
+    
+        
+    
+    
 
     $(document).on('keyup', (e) => {
         if (e.key === 'Escape') exitFullView()

--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -803,6 +803,7 @@ export function exitFullView() {
     $('#moduleProperty').show()
     $('.timing-diagram-panel').show()
     $('.testbench-manual-panel').show()
+    $('.quick-btn').show()
 }
 
 export function fullView() {
@@ -814,7 +815,8 @@ export function fullView() {
     $('#moduleProperty').hide()
     $('.timing-diagram-panel').hide()
     $('.testbench-manual-panel').hide()
-    $('#exitView').append(markUp)
+    $('.quick-btn').hide()
+    $('#app').append(markUp)
     $('#exitViewBtn').on('click', exitFullView)
 }
 /** 

--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -794,31 +794,6 @@ function setupPanelListeners(panelSelector) {
     })
 }
 
-export function exitFullView() {
-    $('.navbar').show()
-    $('.modules').show()
-    $('.report-sidebar').show()
-    $('#tabsBar').show()
-    $('#exitViewBtn').remove()
-    $('#moduleProperty').show()
-    $('.timing-diagram-panel').show()
-    $('.testbench-manual-panel').show()
-    $('.quick-btn').show()
-}
-
-export function fullView() {
-    const markUp = `<button id='exitViewBtn' >Exit Full Preview</button>`
-    $('.navbar').hide()
-    $('.modules').hide()
-    $('.report-sidebar').hide()
-    $('#tabsBar').hide()
-    $('#moduleProperty').hide()
-    $('.timing-diagram-panel').hide()
-    $('.testbench-manual-panel').hide()
-    $('.quick-btn').hide()
-    $('#app').append(markUp)
-    $('#exitViewBtn').on('click', exitFullView)
-}
 /** 
     Fills the elements that can be displayed in the subcircuit, in the subcircuit menu
 **/


### PR DESCRIPTION
Fixes #63,#83

#### Describe the changes you have made in this PR -
now the exit preview button is working fine as the element needs to be added to the app component and the quick panel needs to hide. 

### Screenshots of the changes (If any) -
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/82756460/212134881-949647b6-e0de-4014-b341-e6d7ec9c5e87.gif)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 