### PR TITLE
fix: delete Circuit button bug fixed

### DIFF
--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -25,7 +25,7 @@
                     @click="switchCircuit(element.id)"
                 >
                     <span class="circuitName noSelect">
-                        {{ truncateString(scopeList[element.id].name, 18) }}
+                        {{ truncateString(scopeList[element.id  as keyof typeof scopeList]['name'], 18) }}
                     </span>
                     <span
                         id="scope.id"


### PR DESCRIPTION
Fixes #61 
the error is telling us that "element.id" in 28th line implicitly has an 'any' type so it can not be used as an index.
So I changed it's type, so that element.id can be used as a key for the object "scopeList".