### PR TITLE
fix: delete circuit button error

### DIFF
--- a/src/simulator/src/circuit.js
+++ b/src/simulator/src/circuit.js
@@ -138,7 +138,7 @@ export function deleteCurrentCircuit(scopeId = globalScope.id) {
             delete scopeList[id]
     }
     $(`#${scope.id}`).remove()
-    delete scopeList[scope.id]
+    scopeList.splice(scope.id, 1);
     switchCircuit(Object.keys(scopeList)[0])
 }
 


### PR DESCRIPTION
Fixes #61 

#### Describe the changes you have made in this PR -
fixed the error when deleting a circuit and creating a new one
1. The main cause was a function in circuit.js file named "deleteCurrentCircuit". This function was removing the the circuits with delete keyword (in scopeList array) which creates an undefined value at that place  so I used splice method instead.

### Screenshots of the changes (If any) -


https://user-images.githubusercontent.com/69336404/213383302-068784df-2079-42bb-ab6d-25e7ef263017.mp4



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 