### PR TITLE
fix:disabled underline on hovering items in Nav Menu

### DIFF
--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -165,6 +165,7 @@ input[type='text']:focus {
 }
 .navbar-menu > li > a:hover {
     border-bottom: 1px solid white;
+    text-decoration: none;
 }
 
 .navbar-menu > li > a:hover span,
@@ -369,6 +370,7 @@ input[type='text']:focus {
 .dropdown-menu > li > a:hover {
     border-radius: 7px;
     opacity: 1;
+
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
Fixes #80

#### Describe the changes you have made in this PR -
To disable the underline after hovering on Navbar Menu, I just made text-decoration: none under ".navbar-menu > li > a:hover" in "src/styles/css/main.stylesheet.css" file.
### Screenshots of the changes (If any) -