### PR TITLE
fix: disabled underline on hovering items in Nav Menu

### DIFF
--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -165,6 +165,7 @@ input[type='text']:focus {
 }
 .navbar-menu > li > a:hover {
     border-bottom: 1px solid white;
+    text-decoration: none;
 }
 
 .navbar-menu > li > a:hover span,
@@ -200,6 +201,7 @@ input[type='text']:focus {
 
 .account-btn:hover {
     border-bottom: 1px solid white;
+    text-decoration: none;
 }
 
 .user-field {


### PR DESCRIPTION
Fixes #80 

#### Describe the changes you have made in this PR -
I just add "text-decoration:none" under ".navbar-menu > li > a:hover" in "src/styles/css/main.stylesheet.css" file.
