### PR TITLE
Fixed #80 Disable text underline on hovering items in Nav Menu

### DIFF
--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -141,6 +141,7 @@ input[type='text']:focus {
     padding: 2px 8px;
     transition: all 0.2s ease-in-out;
     margin-right: 10px;
+   text-decoration: none;
 }
 
 .navbar-menu > li > a span,


### PR DESCRIPTION
Before there were 2 underlines in the Navbar

Before:

![BEFORE_CIRCUIT](https://user-images.githubusercontent.com/105926192/222192949-7df31d76-cf9c-461e-8664-d012e2c0ff91.png)


After:
![AFTER-circuit](https://user-images.githubusercontent.com/105926192/222193006-9015cd27-6ba5-4282-aec9-4b9642fda0e0.png)
