### PR TITLE
fix(contextMenu): fix remove unnecessary options from context menu when no item are selected

### DIFF
--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -74,6 +74,16 @@ function showContextMenu() {
         opacity: 1,
     })
 
+    const contextMenuDisplay = simulationArea.lastSelected ? 'block' : 'none'
+
+    const withoutItemSelection = document.querySelectorAll(
+        '#contextMenu li:first-child, #contextMenu li:nth-child(2), #contextMenu li:nth-child(4)'
+    )
+
+    withoutItemSelection.forEach((item) => {
+        item.style.display = contextMenuDisplay
+    })
+
     var windowHeight =
         $('#simulationArea').height() - $('#contextMenu').height() - 10
     var windowWidth =


### PR DESCRIPTION
Fixes #100 

#### Describe the changes you have made in this PR -
remove unnecessary or unusable options when context menu is opened without selecting any item.

### Screenshots of the changes (If any) -
![image](https://user-images.githubusercontent.com/96580571/222916223-e636fda3-788f-4f3b-adb0-1e10115e84e8.png)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 