### PR TITLE
fix: added gap between each timing-diagram

### DIFF
--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -1734,6 +1734,7 @@ input[type='range']::-webkit-slider-thumb {
 .panel-button {
     cursor: pointer;
     padding: 2px;
+    margin: 2px
 }
 
 .draggable-panel-css .maximize {


### PR DESCRIPTION
Fixes #115 

#### Describe the changes you have made in this PR -
Added spacing between timing-diagram buttons.

### Screenshots of the changes (If any) -
<img width="486" alt="Screenshot 2023-03-08 at 7 52 23 PM" src="https://user-images.githubusercontent.com/96587705/223737765-efaa0b5a-3719-4ece-8748-5d16418a5d0c.png">
