### PR TITLE
feat(i18n): add i18n support, add in save image box,layout box,timing diagram,report issue

### DIFF
--- a/src/components/DialogBox/SaveImage.vue
+++ b/src/components/DialogBox/SaveImage.vue
@@ -5,7 +5,9 @@
     >
         <v-card class="messageBoxContent">
             <v-card-text>
-                <p class="dialogHeader">Render Image</p>
+                <p class="dialogHeader">
+                    {{ $t('simulator.panel_header.render_image') }}
+                </p>
                 <v-btn
                     size="x-small"
                     icon
@@ -51,7 +53,11 @@
                                 @click="updateView(1)"
                             >
                                 <input type="radio" name="view" value="full" />
-                                Full Circuit View
+                                {{
+                                    $t(
+                                        'simulator.panel_body.render_image.full_circuit_view'
+                                    )
+                                }}
                             </div>
                             <div
                                 id="radio-current"
@@ -69,7 +75,11 @@
                                     name="view"
                                     value="current"
                                     checked="checked"
-                                />Current View
+                                />{{
+                                    $t(
+                                        'simulator.panel_body.render_image.current_view'
+                                    )
+                                }}
                             </div>
                         </div>
                         <div
@@ -82,7 +92,11 @@
                                     name="transparent"
                                     value="transparent"
                                 />
-                                Transparent Background
+                                {{
+                                    $t(
+                                        'simulator.panel_body.render_image.transparent_background'
+                                    )
+                                }}
                             </label>
                         </div>
                     </div>
@@ -90,7 +104,9 @@
                         v-if="toShow == true"
                         class="download-dialog-section-3"
                     >
-                        <span>Resolution:</span>
+                        <span>{{
+                            $t('simulator.panel_body.render_image.resolution')
+                        }}</span>
                         <label class="option custom-radio inline"
                             ><input
                                 type="radio"
@@ -115,7 +131,11 @@
             </v-card-text>
             <v-card-actions>
                 <v-btn class="messageBtn" block @click="renderCircuit()">
-                    Render Circuit Image
+                    {{
+                        $t(
+                            'simulator.panel_body.render_image.render_circuit_image'
+                        )
+                    }}
                 </v-btn>
             </v-card-actions>
         </v-card>

--- a/src/components/Extra.vue
+++ b/src/components/Extra.vue
@@ -127,7 +127,7 @@
                 >
                     <span class="fas fa-pause timing-diagram-pause"></span>
                 </button>
-                1 cycle =
+                {{ $t('simulator.panel_body.timing_diagram.one_cycle') }}
                 <input
                     id="timing-diagram-units"
                     type="number"
@@ -135,7 +135,7 @@
                     autocomplete="off"
                     value="1000"
                 />
-                Units
+                {{ $t('simulator.panel_body.timing_diagram.units') }}
                 <span id="timing-diagram-log"></span>
             </div>
             <div id="plot">
@@ -478,7 +478,9 @@
             data-toggle="modal"
             data-target=".issue"
         >
-            <span class="fa fa-bug"></span>&nbsp;&nbsp;Report an issue</a
+            <span class="fa fa-bug"></span>&nbsp;&nbsp;{{
+                $t('simulator.report_issue')
+            }}</a
         >
     </div>
     <!-- --------------------------------------------------------------------------------------------- -->
@@ -504,12 +506,16 @@
                         <span aria-hidden="true">&times;</span>
                     </button>
                     <div class="container text-center">
-                        <h4>Report an issue</h4>
+                        <h4>{{ $t('simulator.report_issue') }}</h4>
                     </div>
                     <hr />
                     <div id="result" class="container my-2 text-center"></div>
                     <label id="report-label" style="font-weight: lighter"
-                        ><b>Describe your issue:</b></label
+                        ><b>{{
+                            $t(
+                                'simulator.panel_body.report_issue.describe_issue'
+                            )
+                        }}</b></label
                     >
                     <div class="form-group">
                         <textarea
@@ -522,7 +528,14 @@
                         id="email-label"
                         for="emailtext"
                         style="font-weight: lighter"
-                        ><b>Email</b><span> [Optional]</span>:</label
+                        ><b>{{
+                            $t('simulator.panel_body.report_issue.email')
+                        }}</b>
+                        <span>
+                            {{
+                                $t('simulator.panel_body.report_issue.optional')
+                            }}</span
+                        >:</label
                     >
                     <div class="form-group">
                         <input
@@ -539,7 +552,11 @@
                                 type="submit"
                                 class="btn btn-primary"
                             >
-                                Report
+                                {{
+                                    $t(
+                                        'simulator.panel_body.report_issue.report_btn'
+                                    )
+                                }}
                             </button>
                         </center>
                     </div>

--- a/src/components/Panels/PropertiesPanel/LayoutProperty/LayoutProperty.vue
+++ b/src/components/Panels/PropertiesPanel/LayoutProperty/LayoutProperty.vue
@@ -9,7 +9,7 @@
                     variant="text"
                     icon="mdi-minus"
                 />
-                <span>Width</span>
+                <span>{{ $t('simulator.panel_body.layout.width') }}</span>
                 <v-btn
                     id="increaseLayoutWidth"
                     title="Increase Width"
@@ -24,7 +24,7 @@
                     variant="text"
                     icon="mdi-minus"
                 />
-                <span>Height</span>
+                <span>{{ $t('simulator.panel_body.layout.height') }}</span>
                 <v-btn
                     id="increaseLayoutHeight"
                     title="Increase Height"
@@ -33,11 +33,13 @@
                 />
             </div>
             <div class="">
-                <span>Reset all nodes:</span>
+                <span>{{
+                    $t('simulator.panel_body.layout.reset_all_nodes')
+                }}</span>
                 <v-btn id="layoutResetNodes" variant="text" icon="mdi-sync" />
             </div>
             <div class="layout-title">
-                <span>Title</span>
+                <span>{{ $t('simulator.panel_body.layout.title') }}</span>
                 <div class="layout--btn-group">
                     <v-btn
                         id="layoutTitleUp"
@@ -67,7 +69,9 @@
                 </div>
             </div>
             <div class="layout-title--enable">
-                <span>Title Enabled:</span>
+                <span>{{
+                    $t('simulator.panel_body.layout.title_enabled')
+                }}</span>
                 <label class="switch">
                     <input id="toggleLayoutTitle" type="checkbox" checked />
                     <span class="slider"></span>
@@ -75,14 +79,14 @@
             </div>
             <div class="">
                 <button id="saveLayout" class="Layout-btn custom-btn--primary">
-                    Save
+                    {{ $t('simulator.panel_body.layout.save') }}
                 </button>
 
                 <button
                     id="cancelLayout"
                     class="Layout-btn custom-btn--tertiary"
                 >
-                    Cancel
+                    {{ $t('simulator.panel_body.layout.cancel') }}
                 </button>
             </div>
         </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,7 +81,8 @@
                 }
             },
             "timing_diagram": {
-                "one_cycle_unit_html": "1 cycle = <br/><input id='timing-diagram-units' type='number' min='1' autocomplete='off' value='1000'><br/>Units"
+                "one_cycle": "1 cycle = ",
+                "units": "Units"
             },
             "verilog_module": {
                 "reset_code": "Reset Code",
@@ -101,7 +102,8 @@
                 "full_circuit_view": "Full Circuit View",
                 "current_view": "Current View",
                 "transparent_background": "Transparent Background",
-                "resolution": "Resolution:"
+                "resolution": "Resolution:",
+                "render_circuit_image": "Render Circuit Image"
             },
             "context_menu": {
                 "paste": "Paste",
@@ -119,7 +121,8 @@
             },
             "report_issue": {
                 "describe_issue": "Describe your issue:",
-                "email_html": "<b>Email</b><span> [Optional]</span>:",
+                "email": "Email",
+                "optional": " [Optional]",
                 "report_btn": "Report"
             }
         },

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -81,7 +81,8 @@
                 }
             },
             "timing_diagram": {
-                "one_cycle_unit_html": "1 साइकिल = <br/><input id='timing-diagram-units' type='number' min='1' autocomplete='off' value='1000'><br/>यूनिट"
+                "one_cycle": "1 साइकिल = ",
+                "units": "यूनिट"
             },
             "verilog_module": {
                 "reset_code": "कोड रिसेट करें",
@@ -101,7 +102,8 @@
                 "full_circuit_view": "सर्किट का पूर्ण दृश्य देखें",
                 "current_view": "वर्तमान का दृश्य",
                 "transparent_background": "बैकग्राउंड ट्रांसपेरेंट करें",
-                "resolution": "रेजोलुएशन"
+                "resolution": "रेजोलुएशन",
+                "render_circuit_image": "सर्किट छवि प्रस्तुत करें"
             },
             "context_menu": {
                 "paste": "पेस्ट करें",
@@ -119,7 +121,8 @@
             },
             "report_issue": {
                 "describe_issue": "अपनी समस्या का वर्णन करें:",
-                "email_html": "<b>ईमेल</b><span> [वैकल्पिक]</span>:",
+                "email": "ईमेल",
+                "optional": " [वैकल्पिक]",
                 "report_btn": "रिपोर्ट करें"
             }
         },


### PR DESCRIPTION
Fixes #120 

#### Describe the changes you have made in this PR -
added i18n support for  layout box, save image box, timing diagram box, report issue form.
### Screenshots of the changes (If any) -

![Screenshot from 2023-03-09 23-30-31](https://user-images.githubusercontent.com/96580571/224116310-2b2cccab-2838-4a4b-914f-795781239561.png)
![Screenshot from 2023-03-09 23-30-11](https://user-images.githubusercontent.com/96580571/224116317-4ef2ec88-b3c0-4568-866e-6572026d748d.png)
![Screenshot from 2023-03-09 23-29-36](https://user-images.githubusercontent.com/96580571/224116323-c5b76373-cb86-44cb-9443-947c5fbbbb58.png)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 