### PR TITLE
fix(links): add links loading support from NAVBAR_DATA.json with all attributes support

### DIFF
--- a/src/components/Dropdown/DropDown.vue
+++ b/src/components/Dropdown/DropDown.vue
@@ -10,6 +10,14 @@
                         : ''
                 "
                 style="white-space: pre-line"
+                v-bind="
+                    Object.fromEntries(
+                        listItem.attributes.map((attr) => [
+                            attr.name,
+                            attr.value,
+                        ])
+                    )
+                "
             >
                 {{
                     $t('simulator.nav.' + dropDownHeader + '.' + listItem.item)


### PR DESCRIPTION
Fixes non working links in help section of navbar

#### Describe the changes you have made in this PR -
binded the attributes from NAVBAR_DATA.json to the links made by dropdown.vue component

### Screenshots of the changes (If any) -
N/A can be easily checked through the netlify preview build linked below

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 