### PR TITLE
fix: double undo in context menu #152

### DIFF
--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -70,7 +70,6 @@ export default {
                 deleteSelected()
             } else if (id == 4) {
                 undo()
-                undo()
             } else if (id == 5) {
                 createNewCircuitScope()
             } else if (id == 6) {


### PR DESCRIPTION
Fixes #152 

## Describe the changes you have made in this PR -
Fixed the double undo bug in the context menu. Now only the undo operation is performed only once instead of twice when we click the undo in the Context Menu.

### Screenshots of the changes (If any) -

https://user-images.githubusercontent.com/86093112/228747808-a793d146-cf3f-487b-ae14-424cc4afd916.mp4




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 