### PR TITLE
feat(gsoc): update vite build directory for vue simualtor integration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  command = "npm run build && mkdir -p ./dist && cp -r ../public/* ./dist/ && mv ./dist/simulatorvue/index.html ./dist/"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: [],
+};

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,3 +1,0 @@
-<template>
-    <h2 class="text-center">go to '/simulator' for CircuitVerse Simulator</h2>
-</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,10 +4,10 @@ import simulator from '../pages/simulator.vue'
 const routes = [
     {
         path: '/',
-        redirect: '/simulatorvue',
+        redirect: '/simulatorvue', // @TODO: update later back to /simulator
     },
     {
-        path: '/simulatorvue',
+        path: '/simulatorvue', // @TODO: update later back to /simulator
         name: 'simulator',
         component: simulator,
     },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,16 +1,13 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import index from '../pages/index.vue'
 import simulator from '../pages/simulator.vue'
 
 const routes = [
     {
         path: '/',
-        // name: 'index',
-        // component: index,
-        redirect: '/simulator',
+        redirect: '/simulatorvue',
     },
     {
-        path: '/simulator',
+        path: '/simulatorvue',
         name: 'simulator',
         component: simulator,
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,7 +27,10 @@ export default defineConfig({
             '@': fileURLToPath(new URL('./src/components', import.meta.url)),
         },
     },
+    base: '/simulatorvue/',
     build: {
+        outDir: '../public/simulatorvue',
+        assetsDir: 'assets',
         chunkSizeWarningLimit: 1600,
     },
 })


### PR DESCRIPTION
Fixes #165 

### Describe the changes you have made in this PR -

#### UPDATE 1:

set the build directory to  public/simulatorvue folder in the main repository 

```
base: '/simulatorvue/',
    build: {
        outDir: '../public/simulatorvue',
        assetsDir: 'assets',
        chunkSizeWarningLimit: 1600,
    },
```

#### UPDATE 2:

change the vue-simulator route from `/simulator` to `/simulatorvue` (for time being until feature flags are added) 

### Screenshots of the changes (If any) -

N/A

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 