### PR TITLE
feat(gsoc): update vite.config.ts to setup proxy in dev environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,8 @@ import vueI18n from '@intlify/vite-plugin-vue-i18n'
 // https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
 import vuetify from 'vite-plugin-vuetify'
 
+const proxyUrl:string = 'http://localhost:3000';
+
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [
@@ -32,5 +34,18 @@ export default defineConfig({
         outDir: '../public/simulatorvue',
         assetsDir: 'assets',
         chunkSizeWarningLimit: 1600,
+    },
+    server: {
+        proxy: {
+            ...(process.env.NODE_ENV === 'development' && {
+                '^/(?!(simulatorvue)).*': {
+                    target: proxyUrl,
+                    changeOrigin: true,
+                    headers: {
+                        origin: proxyUrl,
+                    },
+                },
+            }),
+        },
     },
 })


### PR DESCRIPTION
Fixes #168 

#### Describe the changes you have made in this PR -

- [ ] add vite proxy setup in vite.config.js to proxy all request other than the path /simulatorvue to the main repo dev server (running at localhost:3000  // can be changed easily according to requirements) 

### Screenshots of the changes (If any) -
N/A


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 