### PR TITLE
fix(key-binding): fix keybinding not working on the vue simulator

### DIFF
--- a/src/components/DialogBox/CustomShortcut.vue
+++ b/src/components/DialogBox/CustomShortcut.vue
@@ -84,6 +84,10 @@ const keyOptions = ref([])
 const targetPref = ref(null)
 
 onMounted(() => {
+    if (localStorage.userKeys) {
+        checkUpdate()
+        addKeys('user')
+    } else setDefault()
     SimulatorState.dialogBox.customshortcut_dialog = false
     keyOptions.value = Object.entries(defaultKeys)
 })


### PR DESCRIPTION
Fixes # key binding not working issue

#### Describe the changes you have made in this PR -

added setup user keybinding if present or else setup default keybinding 
also if userkeys have some keys missing automatically bind those to defualt keys 

### Screenshots of the changes (If any) -

N/A

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 