### PR TITLE
feat(gsoc): convert timing diagram to vue component 

### DIFF
--- a/src/assets/constants/Panels/TimingDiagramPanel/buttons.json
+++ b/src/assets/constants/Panels/TimingDiagramPanel/buttons.json
@@ -1,0 +1,79 @@
+[
+    {
+        "title": "Decrease Size",
+        "icon": "fa-chevron-left",
+        "class": "timing-diagram-smaller",
+        "type": "primary",
+        "click": "smaller"
+    },
+    {
+        "title": "Increase Size",
+        "icon": "fa-chevron-right",
+        "class": "timing-diagram-larger",
+        "type": "primary",
+        "click": "larger"
+    },
+    {
+        "title": "Decrease Height",
+        "icon": "fa-chevron-up",
+        "class": "timing-diagram-small-height",
+        "type": "primary",
+        "click": "smallHeight"
+    },
+    {
+        "title": "Increase Height",
+        "icon": "fa-chevron-down",
+        "class": "timing-diagram-large-height",
+        "type": "primary",
+        "click": "largeHeight"
+    },
+    {
+        "title": "Download As Image",
+        "icon": "fa-download",
+        "class": "timing-diagram-download",
+        "type": "primary",
+        "click": "download"
+    },
+    {
+        "title": "Reset Timing Diagram",
+        "icon": "fa-undo",
+        "class": "timing-diagram-reset",
+        "type": "tertiary",
+        "click": "reset"
+    },
+    {
+        "title": "Autocalibrate Cycle Units",
+        "icon": "fa-magic",
+        "class": "timing-diagram-calibrate",
+        "type": "tertiary",
+        "click": "calibrate"
+    },
+    {
+        "title": "Zoom In",
+        "icon": "fa-search-plus",
+        "class": "timing-diagram-zoom-in",
+        "type": "primary",
+        "click": "zoomIn"
+    },
+    {
+        "title": "Zoom Out",
+        "icon": "fa-search-minus",
+        "class": "timing-diagram-zoom-out",
+        "type": "primary",
+        "click": "zoomOut"
+    },
+    {
+        "title": "Resume auto-scroll",
+        "icon": "fa-play",
+        "class": "timing-diagram-resume",
+        "type": "primary",
+        "click": "resume"
+    },
+    {
+        "title": "Pause auto-scroll",
+        "icon": "fa-pause",
+        "class": "timing-diagram-pause",
+        "type": "primary",
+        "click": "pause"
+    }
+]

--- a/src/components/Extra.vue
+++ b/src/components/Extra.vue
@@ -33,113 +33,7 @@
 
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Timing Diagram Panel -->
-    <div class="timing-diagram-panel draggable-panel">
-        <!-- Timing Diagram Panel -->
-        <div class="panel-header">
-            Timing Diagram
-            <span class="fas fa-minus-square minimize panel-button"></span>
-            <span
-                class="fas fa-external-link-square-alt maximize panel-button-icon"
-            ></span>
-        </div>
-        <div class="panel-body">
-            <div class="timing-diagram-toolbar noSelect">
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Decrease Size"
-                >
-                    <span
-                        class="fas fa-chevron-left timing-diagram-smaller panel-button-icon"
-                    ></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Increase Size"
-                >
-                    <span
-                        class="fas fa-chevron-right timing-diagram-larger panel-button-icon"
-                    ></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Decrease Height"
-                >
-                    <span
-                        class="fas fa-chevron-up timing-diagram-small-height panel-button-icon"
-                    ></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Increase Height"
-                >
-                    <span
-                        class="fas fa-chevron-down timing-diagram-large-height panel-button-icon"
-                    ></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Download As Image"
-                >
-                    <span
-                        class="fas fa-download timing-diagram-download"
-                    ></span>
-                </button>
-                <button
-                    class="custom-btn--tertiary panel-button"
-                    title="Reset Timing Diagram"
-                >
-                    <span class="fas fa-undo timing-diagram-reset"></span>
-                </button>
-                <button
-                    class="custom-btn--tertiary panel-button"
-                    title="Autocalibrate Cycle Units"
-                >
-                    <span class="fas fa-magic timing-diagram-calibrate"></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Zoom In"
-                >
-                    <span
-                        class="fas fa-search-plus timing-diagram-zoom-in"
-                    ></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Zoom Out"
-                >
-                    <span
-                        class="fas fa-search-minus timing-diagram-zoom-out"
-                    ></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Resume auto-scroll"
-                >
-                    <span class="fas fa-play timing-diagram-resume"></span>
-                </button>
-                <button
-                    class="custom-btn--primary panel-button"
-                    title="Pause auto-scroll"
-                >
-                    <span class="fas fa-pause timing-diagram-pause"></span>
-                </button>
-                1 cycle =
-                <input
-                    id="timing-diagram-units"
-                    type="number"
-                    min="1"
-                    autocomplete="off"
-                    value="1000"
-                />
-                Units
-                <span id="timing-diagram-log"></span>
-            </div>
-            <div id="plot">
-                <canvas id="plotArea"></canvas>
-            </div>
-        </div>
-    </div>
+    <TimingDiagramPanel />
     <!-- --------------------------------------------------------------------------------------------- -->
 
     <!-- --------------------------------------------------------------------------------------------- -->
@@ -490,6 +384,7 @@
 import VerilogEditorPanel from './Panels/VerilogEditorPanel/VerilogEditorPanel.vue'
 import ElementsPanel from './Panels/ElementsPanel/ElementsPanel.vue'
 import PropertiesPanel from './Panels/PropertiesPanel/PropertiesPanel.vue'
+import TimingDiagramPanel from './Panels/TimingDiagramPanel/TimingDiagramPanel.vue'
 import TabsBar from './TabsBar/TabsBar.vue'
 import CombinationalAnalysis from './DialogBox/CombinationalAnalysis.vue'
 import HexBinDec from './DialogBox/HexBinDec.vue'

--- a/src/components/Panels/Shared/PanelHeader.vue
+++ b/src/components/Panels/Shared/PanelHeader.vue
@@ -11,3 +11,12 @@ const props = defineProps({
     headerTitle: { type: String, default: 'Panel Header' },
 })
 </script>
+
+<style scoped>
+.fa-external-link-square-alt {
+    cursor: pointer;
+}
+.fa-minus-square {
+    cursor: pointer;
+}
+</style>

--- a/src/components/Panels/TimingDiagramPanel/TimingDiagramButtons.vue
+++ b/src/components/Panels/TimingDiagramPanel/TimingDiagramButtons.vue
@@ -1,0 +1,28 @@
+<template>
+    <button :class="'custom-btn--' + type + ' panel-button'" :title="title">
+        <span :class="'fas ' + icon + ' ' + btnClass"></span>
+    </button>
+</template>
+
+<script lang="ts" setup>
+import { defineProps } from 'vue'
+
+defineProps({
+    title: {
+        type: String,
+        required: true,
+    },
+    icon: {
+        type: String,
+        required: true,
+    },
+    btnClass: {
+        type: String,
+        required: true,
+    },
+    type: {
+        type: String,
+        required: true,
+    },
+})
+</script>

--- a/src/components/Panels/TimingDiagramPanel/TimingDiagramButtons.vue
+++ b/src/components/Panels/TimingDiagramPanel/TimingDiagramButtons.vue
@@ -5,8 +5,6 @@
 </template>
 
 <script lang="ts" setup>
-import { defineProps } from 'vue'
-
 defineProps({
     title: {
         type: String,

--- a/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
+++ b/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
@@ -1,0 +1,76 @@
+<template>
+    <div class="timing-diagram-panel draggable-panel">
+        <!-- Timing Diagram Panel -->
+        <div class="panel-header">
+            Timing Diagram
+            <span class="fas fa-minus-square minimize panel-button"></span>
+            <span
+                class="fas fa-external-link-square-alt maximize panel-button-icon"
+            ></span>
+        </div>
+        <div class="panel-body">
+            <div class="timing-diagram-toolbar noSelect">
+                <TimingDiagramButtons
+                    v-for="button in buttons"
+                    :key="button.title"
+                    :title="button.title"
+                    :icon="button.icon"
+                    :btn-class="button.class"
+                    class="timing-diagram-panel-button"
+                    :type="button.type"
+                    @click="
+                        () => {
+                            handleButtonClick(button.click)
+                        }
+                    "
+                />
+                1 cycle =
+                <input
+                    id="timing-diagram-units"
+                    type="number"
+                    min="1"
+                    autocomplete="off"
+                    value="1000"
+                />
+                Units
+                <span id="timing-diagram-log"></span>
+            </div>
+            <div id="plot">
+                <canvas id="plotArea"></canvas>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue'
+import plotArea from '#/simulator/src/plotArea'
+import { buttonActions } from '#/simulator/src/plotArea'
+import TimingDiagramButtons from './TimingDiagramButtons.vue'
+import buttonsJSON from '#/assets/constants/Panels/TimingDiagramPanel/buttons.json'
+
+const buttons = ref(buttonsJSON)
+
+function handleButtonClick(button: string) {
+    console.log('clicked', button)
+    if (button === 'smaller') {
+        $('#plot').width(Math.max($('#plot').width() - 20, 560))
+        plotArea.resize()
+    } else if (button === 'larger') {
+        $('#plot').width($('#plot').width() + 20)
+        plotArea.resize()
+    } else if (button === 'smallHeight') {
+        buttonActions.smallHeight()
+    } else if (button === 'largeHeight') {
+        buttonActions.largeHeight()
+    } else {
+        plotArea[button]()
+    }
+}
+</script>
+
+<style scoped>
+.timing-diagram-panel-button {
+    margin-right: 5px;
+}
+</style>

--- a/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
+++ b/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
@@ -24,7 +24,10 @@
                     type="number"
                     min="1"
                     autocomplete="off"
-                    value="1000"
+                    :value="cycleUnits"
+                    @change="handleUnitsChange"
+                    @paste="handleUnitsChange"
+                    @keyup="handleUnitsChange"
                 />
                 Units
                 <span id="timing-diagram-log"></span>
@@ -38,14 +41,29 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue'
-import plotArea from '#/simulator/src/plotArea'
-import { buttonActions } from '#/simulator/src/plotArea'
+import _plotArea from '#/simulator/src/plotArea'
+import { timingDiagramButtonActions } from '#/simulator/src/plotArea'
 import TimingDiagramButtons from './TimingDiagramButtons.vue'
 import buttonsJSON from '#/assets/constants/Panels/TimingDiagramPanel/buttons.json'
 import PanelHeader from '../Shared/PanelHeader.vue'
 
-const buttons = ref<object>(buttonsJSON)
+interface TimingDiagramButton {
+    title: string
+    icon: string
+    class: string
+    type: string
+    click: string
+}
+
+interface PlotArea {
+    resize: () => void
+    [key: string]: () => void
+}
+
+const plotArea: PlotArea = _plotArea
+const buttons = ref<TimingDiagramButton[]>(buttonsJSON)
 const plotRef = ref<HTMLElement | null>(null)
+const cycleUnits = ref(1000)
 
 function handleButtonClick(button: string) {
     console.log('clicked', button)
@@ -63,12 +81,19 @@ function handleButtonClick(button: string) {
         }
         plotArea.resize()
     } else if (button === 'smallHeight') {
-        buttonActions.smallHeight()
+        timingDiagramButtonActions.smallHeight()
     } else if (button === 'largeHeight') {
-        buttonActions.largeHeight()
+        timingDiagramButtonActions.largeHeight()
     } else {
         plotArea[button]()
     }
+}
+
+function handleUnitsChange(event: Event) {
+    const inputElem = event.target as HTMLInputElement
+    const timeUnits = parseInt(inputElem.value, 10)
+    if (isNaN(timeUnits) || timeUnits < 1) return
+    plotArea.cycleUnit = timeUnits
 }
 </script>
 

--- a/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
+++ b/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
@@ -35,7 +35,7 @@
                 Units
                 <span id="timing-diagram-log"></span>
             </div>
-            <div id="plot">
+            <div id="plot" ref="plotRef">
                 <canvas id="plotArea"></canvas>
             </div>
         </div>
@@ -50,14 +50,22 @@ import TimingDiagramButtons from './TimingDiagramButtons.vue'
 import buttonsJSON from '#/assets/constants/Panels/TimingDiagramPanel/buttons.json'
 
 const buttons = ref(buttonsJSON)
+const plotRef = ref<HTMLElement | null>(null)
 
 function handleButtonClick(button: string) {
     console.log('clicked', button)
     if (button === 'smaller') {
-        $('#plot').width(Math.max($('#plot').width() - 20, 560))
+        if (plotRef.value) {
+            plotRef.value.style.width = `${Math.max(
+                plotRef.value.offsetWidth - 20,
+                560
+            )}px`
+        }
         plotArea.resize()
     } else if (button === 'larger') {
-        $('#plot').width($('#plot').width() + 20)
+        if (plotRef.value) {
+            plotRef.value.style.width = `${plotRef.value.offsetWidth + 20}px`
+        }
         plotArea.resize()
     } else if (button === 'smallHeight') {
         buttonActions.smallHeight()
@@ -74,3 +82,5 @@ function handleButtonClick(button: string) {
     margin-right: 5px;
 }
 </style>
+
+<!-- TODO: input element to vue, remove remaining dom manipulation, header component -->

--- a/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
+++ b/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
@@ -1,7 +1,9 @@
 <template>
     <div class="timing-diagram-panel draggable-panel">
         <!-- Timing Diagram Panel -->
-        <PanelHeader title="Timing Diagram" />
+        <PanelHeader
+            :header-title="$t('simulator.panel_header.timing_diagram')"
+        />
         <div class="panel-body">
             <div class="timing-diagram-toolbar noSelect">
                 <TimingDiagramButtons
@@ -18,7 +20,7 @@
                         }
                     "
                 />
-                1 cycle =
+                {{ $t('simulator.panel_body.timing_diagram.one_cycle') }}
                 <input
                     id="timing-diagram-units"
                     type="number"
@@ -29,7 +31,7 @@
                     @paste="handleUnitsChange"
                     @keyup="handleUnitsChange"
                 />
-                Units
+                {{ $t('simulator.panel_body.timing_diagram.units') }}
                 <span id="timing-diagram-log"></span>
             </div>
             <div id="plot" ref="plotRef">

--- a/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
+++ b/src/components/Panels/TimingDiagramPanel/TimingDiagramPanel.vue
@@ -1,13 +1,7 @@
 <template>
     <div class="timing-diagram-panel draggable-panel">
         <!-- Timing Diagram Panel -->
-        <div class="panel-header">
-            Timing Diagram
-            <span class="fas fa-minus-square minimize panel-button"></span>
-            <span
-                class="fas fa-external-link-square-alt maximize panel-button-icon"
-            ></span>
-        </div>
+        <PanelHeader title="Timing Diagram" />
         <div class="panel-body">
             <div class="timing-diagram-toolbar noSelect">
                 <TimingDiagramButtons
@@ -48,8 +42,9 @@ import plotArea from '#/simulator/src/plotArea'
 import { buttonActions } from '#/simulator/src/plotArea'
 import TimingDiagramButtons from './TimingDiagramButtons.vue'
 import buttonsJSON from '#/assets/constants/Panels/TimingDiagramPanel/buttons.json'
+import PanelHeader from '../Shared/PanelHeader.vue'
 
-const buttons = ref(buttonsJSON)
+const buttons = ref<object>(buttonsJSON)
 const plotRef = ref<HTMLElement | null>(null)
 
 function handleButtonClick(button: string) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -84,7 +84,8 @@
                 }
             },
             "timing_diagram": {
-                "one_cycle_unit_html": "1 cycle = <br/><input id='timing-diagram-units' type='number' min='1' autocomplete='off' value='1000'><br/>Units"
+                "one_cycle": "1 Cycle =",
+                "units": "Units"
             },
             "verilog_module": {
                 "reset_code": "Reset Code",

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -84,7 +84,8 @@
                 }
             },
             "timing_diagram": {
-                "one_cycle_unit_html": "1 साइकिल = <br/><input id='timing-diagram-units' type='number' min='1' autocomplete='off' value='1000'><br/>यूनिट"
+                "one_cycle": "1 साइकिल =",
+                "units": "यूनिट्स"
             },
             "verilog_module": {
                 "reset_code": "कोड रिसेट करें",

--- a/src/simulator/src/plotArea.js
+++ b/src/simulator/src/plotArea.js
@@ -419,48 +419,65 @@ const plotArea = {
 }
 export default plotArea
 
-export function setupTimingListeners() {
-    $('.timing-diagram-smaller').on('click', () => {
-        $('#plot').width(Math.max($('#plot').width() - 20, 560))
-        plotArea.resize()
-    })
-    $('.timing-diagram-larger').on('click', () => {
-        $('#plot').width($('#plot').width() + 20)
-        plotArea.resize()
-    })
-    $('.timing-diagram-small-height').on('click', () => {
+const buttonActions = {
+    smallHeight() {
         if (plotHeight >= sh(20)) {
             plotHeight -= sh(5)
             waveFormHeight = plotHeight - 2 * waveFormPadding
         }
-    })
-    $('.timing-diagram-large-height').on('click', () => {
+    },
+    largeHeight() {
         if (plotHeight < sh(50)) {
             plotHeight += sh(5)
             waveFormHeight = plotHeight - 2 * waveFormPadding
         }
-    })
-    $('.timing-diagram-reset').on('click', () => {
-        plotArea.reset()
-    })
-    $('.timing-diagram-calibrate').on('click', () => {
-        plotArea.calibrate()
-    })
-    $('.timing-diagram-resume').on('click', () => {
-        plotArea.resume()
-    })
-    $('.timing-diagram-pause').on('click', () => {
-        plotArea.pause()
-    })
-    $('.timing-diagram-download').on('click', () => {
-        plotArea.download()
-    })
-    $('.timing-diagram-zoom-in').on('click', () => {
-        plotArea.zoomIn()
-    })
-    $('.timing-diagram-zoom-out').on('click', () => {
-        plotArea.zoomOut()
-    })
+    },
+}
+
+export { buttonActions }
+
+export function setupTimingListeners() {
+    // $('.timing-diagram-smaller').on('click', () => {
+    //     $('#plot').width(Math.max($('#plot').width() - 20, 560))
+    //     plotArea.resize()
+    // })
+    // $('.timing-diagram-larger').on('click', () => {
+    //     $('#plot').width($('#plot').width() + 20)
+    //     plotArea.resize()
+    // })
+    // $('.timing-diagram-small-height').on('click', () => {
+    //     if (plotHeight >= sh(20)) {
+    //         plotHeight -= sh(5)
+    //         waveFormHeight = plotHeight - 2 * waveFormPadding
+    //     }
+    // })
+    // $('.timing-diagram-large-height').on('click', () => {
+    //     if (plotHeight < sh(50)) {
+    //         plotHeight += sh(5)
+    //         waveFormHeight = plotHeight - 2 * waveFormPadding
+    //     }
+    // })
+    // $('.timing-diagram-reset').on('click', () => {
+    //     plotArea.reset()
+    // })
+    // $('.timing-diagram-calibrate').on('click', () => {
+    //     plotArea.calibrate()
+    // })
+    // $('.timing-diagram-resume').on('click', () => {
+    //     plotArea.resume()
+    // })
+    // $('.timing-diagram-pause').on('click', () => {
+    //     plotArea.pause()
+    // })
+    // $('.timing-diagram-download').on('click', () => {
+    //     plotArea.download()
+    // })
+    // $('.timing-diagram-zoom-in').on('click', () => {
+    //     plotArea.zoomIn()
+    // })
+    // $('.timing-diagram-zoom-out').on('click', () => {
+    //     plotArea.zoomOut()
+    // })
     $('#timing-diagram-units').on('change paste keyup', function () {
         var timeUnits = parseInt($(this).val(), 10)
         if (isNaN(timeUnits) || timeUnits < 1) return

--- a/src/simulator/src/plotArea.js
+++ b/src/simulator/src/plotArea.js
@@ -419,7 +419,15 @@ const plotArea = {
 }
 export default plotArea
 
-const buttonActions = {
+/**
+ * type {Object} timingDiagramButtonActions
+ * @category plotArea
+ * @description Actions for buttons in timing diagram
+ * @property {function} smallHeight - Decrease waveform height
+ * @property {function} largeHeight - Increase waveform height
+ */
+
+const timingDiagramButtonActions = {
     smallHeight() {
         if (plotHeight >= sh(20)) {
             plotHeight -= sh(5)
@@ -434,7 +442,7 @@ const buttonActions = {
     },
 }
 
-export { buttonActions }
+export { timingDiagramButtonActions }
 
 export function setupTimingListeners() {
     // $('.timing-diagram-smaller').on('click', () => {
@@ -478,11 +486,11 @@ export function setupTimingListeners() {
     // $('.timing-diagram-zoom-out').on('click', () => {
     //     plotArea.zoomOut()
     // })
-    $('#timing-diagram-units').on('change paste keyup', function () {
-        var timeUnits = parseInt($(this).val(), 10)
-        if (isNaN(timeUnits) || timeUnits < 1) return
-        plotArea.cycleUnit = timeUnits
-    })
+    // $('#timing-diagram-units').on('change paste keyup', function () {
+    //     var timeUnits = parseInt($(this).val(), 10)
+    //     if (isNaN(timeUnits) || timeUnits < 1) return
+    //     plotArea.cycleUnit = timeUnits
+    // })
     document.getElementById('plotArea').addEventListener('mousedown', (e) => {
         var rect = plotArea.canvas.getBoundingClientRect()
         var x = sh(e.clientX - rect.left)


### PR DESCRIPTION
Fixes Timing Diagram to Vue component

#### Describe the changes you have made in this PR -

- [x] fix functionality of timing diagram in the Vue simualtor
- [x] remove & reduce DOM manipulation
- [x] remove jQuery 
- [x] add typescript and i18n support
- [x] separate component for buttons to reduce code duplication

### Screenshots of the changes (If any) -

![image](https://github.com/CircuitVerse/cv-frontend-vue/assets/96580571/606f5c24-4f12-4e2c-83e5-12cb0ad9fde6)


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 