### PR TITLE
Update main.stylesheet.css

### DIFF
--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -1973,4 +1973,33 @@ canvas {
     width: 5px;
     height: 5px;
 }
+@media screen and (max-width: 823px) {
+    #radio-current {
+        width: 6vw;
+        font-size: 9px;
+        padding: 0;
+        height: 5vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    div.option {
+        width: 27vw;
+        height: 5vh;
+    }
+    #radio-full {
+        width: 11vw;
+        height: 5vh;
+        font-size: 9px;
+        padding: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .btn-group>.btn:not(:first-child),
+    .btn-group>.btn-group:not(:first-child)>.btn {
+        border-top-left-radius: 0;
+    }
+}
+
 /* STYLE ENDS */


### PR DESCRIPTION
Fixes #


this PR fixes the issue- In Render image container the " current view button" is too big for mobile view #202 
Now, the 'Current View' button doesn't get bigger on the mobile screen.
@Prerna-0202 @Arnabdaz @upsaurav12

https://github.com/CircuitVerse/cv-frontend-vue/assets/101273941/8032bcf1-37ac-4d3c-94d0-c9e938d07e3a






