### PR TITLE
fix: remove 'overflow' property in user-field class

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Satvik Ramaprasad
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -208,7 +208,6 @@ input[type='text']:focus {
     display: inline-block;
     max-width: 11rem;
     white-space: nowrap;
-    overflow: hidden;
     text-overflow: ellipsis;
     text-align: right;
 }


### PR DESCRIPTION

#### This commit removes the 'overflow' property from the user-field class, ensuring that the bottom of the letter "g" in the sign-in interface is now visible. This adjustment is made to enhance the visibility of the text without affecting other elements on the page.

### Before 
![Screenshot 2023-12-18 210101](https://github.com/CircuitVerse/cv-frontend-vue/assets/71400504/09a54086-65df-43cf-9166-0448553d24b9)
### After 
![Screenshot 2023-12-18 210216](https://github.com/CircuitVerse/cv-frontend-vue/assets/71400504/9335586f-9b7b-4a4c-bf7e-d7afaf9a5bf2)