### PR TITLE
feat(Toggle): feat for TabsBar.vue using Pinia Store | #222

### DIFF
--- a/src/components/Extra.vue
+++ b/src/components/Extra.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- TabsBar -->
-    <TabsBar :isSimulationAreaClicked="isSimulationAreaClicked" @changeState="handleStateChange"/>
+    <TabsBar />
     <!-- --------------------------------------------------------------------------------------------- -->
 
     <!-- --------------------------------------------------------------------------------------------- -->
@@ -214,7 +214,7 @@
 
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Simulation Area - Canvas (3) + Help Section-->
-    <div id="simulation" class="simulation" @mousedown="handleSimulationAreaClick">
+    <div id="simulation" class="simulation" @click="callSimulatorAction(true)">
         <!-- <div id="restrictedDiv" class="alert alert-danger display--none"></div> -->
         <div id="canvasArea" class="canvasArea">
             <canvas
@@ -321,25 +321,16 @@ import InsertSubcircuit from './DialogBox/InsertSubcircuit.vue'
 import OpenOffline from './DialogBox/OpenOffline.vue'
 import ReportIssue from './ReportIssue/ReportIssue.vue'
 
-import { ref, defineProps, defineEmits } from 'vue';
+// ------------- Code for id="simulation" `obj : Toggling Tabsbar Effect` -------------
 
-const props = defineProps(['isSimulationAreaClicked']);
-const { emit } = defineEmits();
+import { useActions } from '../store/SimulatorStore/actions';
+const actions = useActions();
 
-const handleTabsBarClick = () => {
-  emit('tabsBarClick');
+const callSimulatorAction = (value: boolean) => {
+    actions.setSimulatorClicked(value);
 };
 
-function handleStateChange(dataFromChild) {
-    // console.log('Received data from TabsBar:', dataFromChild);
-    isSimulationAreaClicked.value = dataFromChild.isSimulationAreaClicked;
-  }
-
-const isSimulationAreaClicked = ref(false);
-
-function handleSimulationAreaClick() {
-  isSimulationAreaClicked.value = true;
-}
+// -------------------------------------------------------
 
 
 </script>

--- a/src/components/Extra.vue
+++ b/src/components/Extra.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- TabsBar -->
-    <TabsBar />
+    <TabsBar :isSimulationAreaClicked="isSimulationAreaClicked" @changeState="handleStateChange"/>
     <!-- --------------------------------------------------------------------------------------------- -->
 
     <!-- --------------------------------------------------------------------------------------------- -->
@@ -214,7 +214,7 @@
 
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Simulation Area - Canvas (3) + Help Section-->
-    <div id="simulation" class="simulation">
+    <div id="simulation" class="simulation" @mousedown="handleSimulationAreaClick">
         <!-- <div id="restrictedDiv" class="alert alert-danger display--none"></div> -->
         <div id="canvasArea" class="canvasArea">
             <canvas
@@ -320,4 +320,26 @@ import CustomShortcut from './DialogBox/CustomShortcut.vue'
 import InsertSubcircuit from './DialogBox/InsertSubcircuit.vue'
 import OpenOffline from './DialogBox/OpenOffline.vue'
 import ReportIssue from './ReportIssue/ReportIssue.vue'
+
+import { ref, defineProps, defineEmits } from 'vue';
+
+const props = defineProps(['isSimulationAreaClicked']);
+const { emit } = defineEmits();
+
+const handleTabsBarClick = () => {
+  emit('tabsBarClick');
+};
+
+function handleStateChange(dataFromChild) {
+    // console.log('Received data from TabsBar:', dataFromChild);
+    isSimulationAreaClicked.value = dataFromChild.isSimulationAreaClicked;
+  }
+
+const isSimulationAreaClicked = ref(false);
+
+function handleSimulationAreaClick() {
+  isSimulationAreaClicked.value = true;
+}
+
+
 </script>

--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -1,5 +1,11 @@
 <template>
-    <div id="tabsBar" class="noSelect pointerCursor" :class="embedClass()">
+    <div
+        id="tabsBar"
+        class="noSelect pointerCursor"
+        :class="embedClass()"
+        :style="{ height: showMaxHeight ? '28px' : 'auto', maxHeight: showMaxHeight ? '28px' : 'none' }"
+        @click="handleTabsBarClick"
+    >
         <draggable
             :key="updateCount"
             v-model="SimulatorState.circuit_list"
@@ -41,6 +47,14 @@
         <button v-if="!isEmbed()" @click="createNewCircuitScope()">
             &#43;
         </button>
+        <button id="toggleBtn" @click="toggleHeight">
+            <svg v-if="showMaxHeight" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M6 9l6 6 6-6"/>
+            </svg>
+            <svg v-else xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M6 15l6-6 6 6"/>
+            </svg>
+        </button>
     </div>
     <!-- <MessageBox
         v-model="SimulatorState.dialogBox.create_circuit"
@@ -60,7 +74,8 @@
 <script lang="ts" setup>
 import draggable from 'vuedraggable'
 import { showMessage, truncateString } from '#/simulator/src/utils'
-import { ref, Ref } from 'vue'
+import { ref, Ref, watch, defineEmits } from 'vue';
+
 import {
     createNewCircuitScope,
     // deleteCurrentCircuit,
@@ -74,7 +89,36 @@ import { closeCircuit } from '../helpers/deleteCircuit/DeleteCircuit.vue'
 
 const SimulatorState = <SimulatorStateType>useState()
 const drag: Ref<boolean> = ref(false)
-const updateCount: Ref<number> = ref(0)
+const updateCount: Ref<number> = ref(0);
+
+
+const props = defineProps(['isSimulationAreaClicked']);
+
+const showMaxHeight = ref(true);
+
+watch(() => {
+    console.log('isSimulationAreaClicked:', props.isSimulationAreaClicked);
+    if (props.isSimulationAreaClicked === true && showMaxHeight.value === false) {
+        // If isSimulationAreaClicked is true and showMaxHeight is false, set showMaxHeight to true
+        showMaxHeight.value = true;
+    }
+});
+
+const emit = defineEmits(['changeState']);
+
+function handleClick() {
+    // Emit the event with necessary data
+    emit('changeState', { data: 'some value to pass to parent' });
+}
+
+function handleTabsBarClick() {
+  emit('changeState', { isSimulationAreaClicked: false });
+}
+
+function toggleHeight() {
+    showMaxHeight.value = !showMaxHeight.value;
+}
+
 // const persistentShow: Ref<boolean> = ref(false)
 // const messageVal: Ref<string> = ref('')
 // const buttonArr: Ref<Array<buttonArrType>> = ref([{ text: '', emitOption: '' }])
@@ -270,6 +314,14 @@ function isEmbed(): boolean {
 </script>
 
 <style scoped>
+#tabsBar{
+    padding-right: 50px;
+    position: relative;
+    overflow: hidden;
+    padding-bottom: 2.5px;
+    z-index: 100;
+}
+
 #tabsBar.embed-tabbar {
     background-color: transparent;
 }
@@ -290,6 +342,12 @@ function isEmbed(): boolean {
     /* border: 1px solid var(--br-circuit-cur); */
 }
 
+#tabsBar button {
+    font-size: 1rem; 
+    height: 20px;
+    width: 20px;
+}
+
 #tabsBar.embed-tabbar button {
     color: var(--text-panel);
     background-color: var(--primary);
@@ -304,6 +362,21 @@ function isEmbed(): boolean {
 .list-group {
     display: inline;
 }
+
+.toolbarButton{
+    height: 22px;
+}
+
+#toggleBtn{
+    position: absolute;
+    right: 2.5px;
+    top: 2.5px;
+}
+
+.tabsbar-close{
+    font-size: 1rem; 
+}
+
 </style>
 
 <!-- TODO: add types for scopelist and fix key issue with draggable -->

--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -86,33 +86,29 @@ import {
 // import MessageBox from '#/components/MessageBox/messageBox.vue'
 import { useState } from '#/store/SimulatorStore/state'
 import { closeCircuit } from '../helpers/deleteCircuit/DeleteCircuit.vue'
-
 const SimulatorState = <SimulatorStateType>useState()
 const drag: Ref<boolean> = ref(false)
 const updateCount: Ref<number> = ref(0);
 
-
-const props = defineProps(['isSimulationAreaClicked']);
+import { useActions } from '../../store/SimulatorStore/actions';
 
 const showMaxHeight = ref(true);
+const actions = useActions();
+const state = useState();
+
+const callSimulatorAction = (value: boolean) => {
+    actions.setSimulatorClicked(value);
+};
 
 watch(() => {
-    console.log('isSimulationAreaClicked:', props.isSimulationAreaClicked);
-    if (props.isSimulationAreaClicked === true && showMaxHeight.value === false) {
-        // If isSimulationAreaClicked is true and showMaxHeight is false, set showMaxHeight to true
+    console.log('state.dialogBox.SimulatorWasClicked:', state.dialogBox.SimulatorWasClicked);
+    if (state.dialogBox.SimulatorWasClicked === true && showMaxHeight.value === false) {
         showMaxHeight.value = true;
     }
 });
 
-const emit = defineEmits(['changeState']);
-
-function handleClick() {
-    // Emit the event with necessary data
-    emit('changeState', { data: 'some value to pass to parent' });
-}
-
 function handleTabsBarClick() {
-  emit('changeState', { isSimulationAreaClicked: false });
+  state.dialogBox.SimulatorWasClicked = false;
 }
 
 function toggleHeight() {

--- a/src/store/SimulatorStore/actions.ts
+++ b/src/store/SimulatorStore/actions.ts
@@ -8,9 +8,14 @@ export const useActions = defineStore('simulatorStore.actions', () => {
         console.log(state.title)
     }
 
+    function setSimulatorClicked(value: boolean): void {
+        state.dialogBox.SimulatorWasClicked = value;
+    }
+
     // Note you are free to define as many internal functions as you want.
     // You only expose the functions that are returned.
     return {
         showTitle,
+        setSimulatorClicked,
     }
 })

--- a/src/store/SimulatorStore/state.ts
+++ b/src/store/SimulatorStore/state.ts
@@ -24,9 +24,11 @@ export interface State {
         open_project_dialog: boolean
         export_project_dialog: boolean
         import_project_dialog: boolean
+        SimulatorWasClicked: boolean
     }
     // createCircuit: Object | { circuitName: string }
     combinationalAnalysis: Object
+    
 }
 
 export const useState = defineStore({
@@ -51,6 +53,7 @@ export const useState = defineStore({
                 open_project_dialog: false,
                 export_project_dialog: false,
                 import_project_dialog: false,
+                SimulatorWasClicked: false,
             },
             // createCircuit: {
             //     circuitName: 'Untitled Circuit',


### PR DESCRIPTION
Fixes #222

## Describe the changes you have made in this PR -

#### 1. TabsBar.vue : 
- I incorporated a toggle button in the top-right corner.
- The toggle functionality is height-based, concealing surplus tabs using overflow.
#### 2. Extra.vue : 
- Calling the state from the Piana store for the simulator which is inside this file. 
#### 3. state.ts : 
- Created a boolean state by name `SimulatorWasClicked`
#### 4. actions.ts : 
- Implemented a function setSimulatorClicked ito update the state's SimulatorWasClicked property with the given boolean value.

## Screenshots of the changes (If any) -
https://github.com/CircuitVerse/cv-frontend-vue/assets/93304796/afe60027-020d-4fc0-8876-73d8d2c96ab8

## Few extra minor changes -
Changes are made to make the vue simulator be consistent with the main simulator. 
#### 1. Adjusted the tabs bar to a smaller height.
#### 2. Ensured uniform alignment and transformed buttons into squares.
#### 3. Reduced the size of the close button.
<img width="464" alt="Screenshot 2023-12-25 at 12 09 41 PM" src="https://github.com/CircuitVerse/cv-frontend-vue/assets/93304796/cb331032-cb96-4888-8f2c-ba03520e2977">

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 