### PR TITLE
feat: fixed printing bool tables

### DIFF
--- a/src/components/DialogBox/BooleanTable.vue
+++ b/src/components/DialogBox/BooleanTable.vue
@@ -1,6 +1,6 @@
 <template>
     <table class="content-table">
-        <tbody style="display: block; max-height: 70vh; overflow-y: scroll">
+        <tbody style="display: block; max-height: 70vh;">
             <tr>
                 <th v-for="tableHeading in tableHeader" :key="tableHeading">
                     {{ tableHeading }}

--- a/src/components/DialogBox/CombinationalAnalysis.vue
+++ b/src/components/DialogBox/CombinationalAnalysis.vue
@@ -699,7 +699,7 @@ function printBooleanTable() {
         table, th, td {border: solid 1px #DDD;border-collapse: 0;}
         tbody {padding: 2px 3px;text-align: center;} 
         </style>`.replace(/\n/g, "")
-    var win = window.open('', '', 'height=1d 400,width=700')
+    var win = window.open('', '', 'height=700,width=700')
     var htmlBody = `
                        <html><head>\
                        <title>Boolean Logic Table</title>\

--- a/src/components/DialogBox/CombinationalAnalysis.vue
+++ b/src/components/DialogBox/CombinationalAnalysis.vue
@@ -8,7 +8,7 @@
         :is-persistent="true"
         :table-header="tableHeader"
         :table-body="tableBody"
-        message-text="BooleanLogicTable"
+        message-text="Boolean Logic Table"
         @button-click="
             (selectedOption, circuitItem, circuitNameVal) =>
                 dialogBoxConformation(selectedOption)
@@ -690,10 +690,16 @@ function generateCircuit() {
 function printBooleanTable() {
     console.log($('.messageBox .v-card-text')[0])
     var sTable = $('.messageBox .v-card-text')[0].innerHTML
+    console.log('This is the table')
     console.log(sTable)
+
     var style =
-        '<style> table {font: 20px Calibri;} table, th, td {border: solid 1px #DDD;border-collapse: collapse;} padding: 2px 3px;text-align: center;} </style>'
-    var win = window.open('', '', 'height=700,width=700')
+        `<style>
+        table {font: 40px Calibri;}
+        table, th, td {border: solid 1px #DDD;border-collapse: 0;}
+        tbody {padding: 2px 3px;text-align: center;} 
+        </style>`.replace(/\n/g, "")
+    var win = window.open('', '', 'height=1d 400,width=700')
     var htmlBody = `
                        <html><head>\
                        <title>Boolean Logic Table</title>\


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
The print tables in boolean tables couldn't generate the whole pdf, instead only a portion of it was visible. I fixed the small issue in UI part, so that the whole truth table could be generated in the PDF format (tldr; scroll issue fixed in print table).
resolve #198 

### Screenshots of the changes (If any) -

#### Before
![image](https://github.com/CircuitVerse/cv-frontend-vue/assets/62395456/b1022404-e7fc-4e41-957d-dc2b3d00655e)
Here, only one page was visible. 

#### After
![image](https://github.com/CircuitVerse/cv-frontend-vue/assets/62395456/427200d2-04ad-4c6a-b7a3-3e05c6ed28af)
Here, all the pages and cells in the table are visible.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 