### PR TITLE
Fixes: 🐞 Bug Canceling save online alert box not working as expected #4522

### DIFF
--- a/src/components/helpers/confirmComponent/ConfirmComponent.vue
+++ b/src/components/helpers/confirmComponent/ConfirmComponent.vue
@@ -84,6 +84,9 @@ const promptStore = usePromptStore()
 
 const confirmation = (selectedOption: string | boolean): void => {
     promptStore.confirm.activate = false
+    if (selectedOption === false) {
+        return
+    }
     for (const button of promptStore.confirm.buttonList) {
         if (button.emitOption == selectedOption) {
             promptStore.resolvePromise(button.emitOption)


### PR DESCRIPTION
Fixes #4522

#### Describe the changes you have made in this PR -
Made changes so that when Cancel button is pressed, it just returns the function and does not perform any other task.


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 