### PR TITLE
Added matching categories to the search results of ElementsPanel for better accessibility.

### DIFF
--- a/src/components/Panels/ElementsPanel/ElementsPanel.vue
+++ b/src/components/Panels/ElementsPanel/ElementsPanel.vue
@@ -42,6 +42,46 @@
                     <img :src="element.imgURL" :alt="element.name" />
                 </div>
             </div>
+            <v-expansion-panels
+                v-if="elementInput && searchCategories().length"
+                id="menu"
+                class="accordion"
+                variant="accordion"
+            >
+                <v-expansion-panel
+                    v-for="category in searchCategories()"
+                    :key="category[0]"
+                >
+                    <v-expansion-panel-title>
+                        {{
+                            $t(
+                                'simulator.panel_body.circuit_elements.expansion_panel_title.' +
+                                    category[0]
+                            )
+                        }}
+                    </v-expansion-panel-title>
+                    <v-expansion-panel-text eager>
+                        <div class="panel customScroll">
+                            <div
+                                v-for="element in category[1]"
+                                :id="element.name"
+                                :key="element"
+                                :title="element.label"
+                                class="icon logixModules"
+                                @click="createElement(element.name)"
+                                @mousedown="createElement(element.name)"
+                                @mouseover="getTooltipText(element.name)"
+                                @mouseleave="tooltipText = 'null'"
+                            >
+                                <img
+                                    :src="element.imgURL"
+                                    :alt="element.name"
+                                />
+                            </div>
+                        </div>
+                    </v-expansion-panel-text>
+                </v-expansion-panel>
+            </v-expansion-panels>
             <div
                 v-if="elementInput && !searchElements().length"
                 class="search-results"
@@ -161,6 +201,18 @@ function searchElements() {
         }
     }
     return finalResult
+}
+
+function searchCategories() {
+    const result = panelData.filter((category) => {
+        const categoryName = category[0];
+        const categoryNameWords = categoryName.split(' ');
+
+        return categoryNameWords.some((word) =>
+            word.toLowerCase().startsWith(elementInput.value.toLowerCase())
+        );
+    })
+    return result;
 }
 
 function createElement(elementName) {

--- a/src/components/Panels/ElementsPanel/ElementsPanel.vue
+++ b/src/components/Panels/ElementsPanel/ElementsPanel.vue
@@ -42,12 +42,6 @@
                     <img :src="element.imgURL" :alt="element.name" />
                 </div>
             </div>
-            <div
-                v-if="elementInput && !searchElements().length"
-                class="search-results"
-            >
-                {{ $t('simulator.panel_body.circuit_elements.search_result') }}
-            </div>
             <v-expansion-panels
                 v-if="elementInput && searchCategories().length"
                 id="menu"
@@ -88,6 +82,12 @@
                     </v-expansion-panel-text>
                 </v-expansion-panel>
             </v-expansion-panels>
+            <div
+                v-if="elementInput && !searchElements().length && !searchCategories().length"
+                class="search-results"
+            >
+                {{ $t('simulator.panel_body.circuit_elements.search_result') }}
+            </div>
             <v-expansion-panels
                 v-if="!elementInput"
                 id="menu"

--- a/src/components/Panels/ElementsPanel/ElementsPanel.vue
+++ b/src/components/Panels/ElementsPanel/ElementsPanel.vue
@@ -42,6 +42,12 @@
                     <img :src="element.imgURL" :alt="element.name" />
                 </div>
             </div>
+            <div
+                v-if="elementInput && !searchElements().length"
+                class="search-results"
+            >
+                {{ $t('simulator.panel_body.circuit_elements.search_result') }}
+            </div>
             <v-expansion-panels
                 v-if="elementInput && searchCategories().length"
                 id="menu"
@@ -82,12 +88,6 @@
                     </v-expansion-panel-text>
                 </v-expansion-panel>
             </v-expansion-panels>
-            <div
-                v-if="elementInput && !searchElements().length"
-                class="search-results"
-            >
-                {{ $t('simulator.panel_body.circuit_elements.search_result') }}
-            </div>
             <v-expansion-panels
                 v-if="!elementInput"
                 id="menu"


### PR DESCRIPTION
Fixes #262

### Describe the changes you have made in this PR -
Previously, when searching for something on the search bar of ElementsPanel, it used to give elements that contained the search input as a substring in the name of the element.

I have added a new section that will show the categories that match the search input. To do the same, I have added another ```v-expansion-panel``` below the one that shows matched elements.
I haven't changed the code that is used to show all categories. I did it because I believe it will increase the readability of the code.

This feature will improve the accessibility of the search option. **It will be even more helpful if, at a later stage, more categories are added.**

#### Search Algorithm:

The search algorithm finds categories, for which any word in the category name starts with the search input. (Comparision is done after converting everything to lowercase.)

For example:
- search-input = "Inp" will match with  category = "Input" 
- search-input = "Elemen" will match with  category = "Sequential Elements" 
- search-input = "Plexe" will match with  category = "Decoders & Plexers" 

### Screenshots of the changes (If any) -

![Screenshot 2024-01-21 at 11 30 39 PM](https://github.com/CircuitVerse/cv-frontend-vue/assets/97349505/f20c3ab5-cac7-4315-95bc-5dfd5385b5a6)
![Screenshot 2024-01-21 at 11 31 58 PM](https://github.com/CircuitVerse/cv-frontend-vue/assets/97349505/fec6c081-d694-4e28-81ad-5da687f69833)
![Screenshot 2024-01-21 at 11 33 26 PM](https://github.com/CircuitVerse/cv-frontend-vue/assets/97349505/84892a51-f92e-4f95-976f-2f488403ae45)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

