### PR TITLE
Feat : Added transiton when arow changes it direction. 

### DIFF
--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -46,7 +46,15 @@
             &#43;
         </button>
         <button class="tabsbar-toggle" @click="toggleHeight">
-            <i :class="showMaxHeight ? 'fa fa-chevron-down' : 'fa fa-chevron-up'"></i>
+            <i
+                class="fa fa-chevron-up"
+                :style="
+                    showMaxHeight
+                        ? 'transform: rotate(180deg); transition: transform 0.5s'
+                        : 'transform: rotate(0deg); transition: transform 0.5s'
+                "
+            >
+            </i>
         </button>
     </div>
     <!-- <MessageBox


### PR DESCRIPTION
Fixes #273 

#### Describe the changes you have made in this PR -

- Removed interchanging of two different icons.
- Rotated the `fa fa-chevron-up` icon with a transition of 0.5s  

### Screencasts of the changes

Before:-
[Screencast from 2024-02-13 12-53-23.webm](https://github.com/CircuitVerse/cv-frontend-vue/assets/124715224/d827738d-65f0-4127-9ecc-5bf7490062a0)

After:-

[Screencast from 2024-02-13 12-53-54.webm](https://github.com/CircuitVerse/cv-frontend-vue/assets/124715224/1899a059-fbb3-44bd-a0a0-6c3dae96ba0d)

Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 