### PR TITLE
Fix: First option of navbar's dropdown was hidden

### DIFF
--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -289,7 +289,7 @@ function isEmbed(): boolean {
     position: relative;
     overflow: hidden;
     padding-bottom: 2.5px;
-    z-index: 100;
+    z-index: 1;
 }
 
 #tabsBar.embed-tabbar {


### PR DESCRIPTION
Fixes #277 

#### Describe the changes you have made in this PR -
I have changed the z-index property of the component that is displaying over the options of the Navbar.
### Screenshots of the changes  -

After the change:
![circuitverse issue solved](https://github.com/CircuitVerse/cv-frontend-vue/assets/87687490/a1568d57-a915-48ec-ae6a-c7579bb3acbf)

