### PR TITLE
Fix: 'Report System' Element Not Highlighted in Tour Guide

### DIFF
--- a/src/simulator/src/tutorials.js
+++ b/src/simulator/src/tutorials.js
@@ -74,7 +74,7 @@ export const tour = [
     //     },
     // },
     {
-        element: '.fa-bug',
+        element: '.report-sidebar a',
         popover: {
             className: 'bug-guide',
             title: 'Report System',

--- a/src/styles/tutorials.scss
+++ b/src/styles/tutorials.scss
@@ -39,7 +39,7 @@
 }
 
 .bug-guide .right {
-    top: 110px !important;
+    top: 114px !important;
 }
 
 .tourHelpStep.driver-popover-title {


### PR DESCRIPTION
Fixes #283

#### Describe the changes you have made in this PR -

- Updated the tour guide configuration (`tour` array) to replace the element selector to the correct element.
- Adjusted the CSS styling of `.bug-guide .right` class, ensuring that the popover tip points directly to the report system button.

### Screenshots of the changes (If any) -
- before the changes:
![tutorial-guide-bug](https://github.com/CircuitVerse/cv-frontend-vue/assets/89861718/29b0ab08-1d51-43b9-a81f-f0ae23f31b11)
- after the changes:
![tutorial-guide-highlighting-issue-resolved](https://github.com/CircuitVerse/cv-frontend-vue/assets/89861718/0c5d1bbc-5514-41b3-9ca1-2cad1010f768)
