### PR TITLE
Fix: Circuit Elements Panel Bug Hiding Lower Section

### DIFF
--- a/src/components/Panels/ElementsPanel/ElementsPanel.vue
+++ b/src/components/Panels/ElementsPanel/ElementsPanel.vue
@@ -234,13 +234,7 @@ function getTooltipText(elementName) {
 </script>
 
 <style scoped>
-.panel-body {
-    height: 415px;
-    overflow-y: auto;
-}
-
-.panel-body::-webkit-scrollbar {
-    width: 0;
-    height: 0;
+.v-expansion-panel-title {
+    min-height: 36px;
 }
 </style>

--- a/src/components/Panels/ElementsPanel/ElementsPanel.vue
+++ b/src/components/Panels/ElementsPanel/ElementsPanel.vue
@@ -233,4 +233,14 @@ function getTooltipText(elementName) {
 }
 </script>
 
-<style scoped></style>
+<style scoped>
+.panel-body {
+    height: 415px;
+    overflow-y: auto;
+}
+
+.panel-body::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+}
+</style>


### PR DESCRIPTION
Fixes #285 

#### Describe the changes you have made in this PR -
Adjusted the styling of the panel body in the `ElementsPanel` component to enable vertical scrolling. This ensures that the panel remains fully accessible even when expanded elements exceed the viewport height.

### Screenshots of the changes (If any) -
- before the changes:

https://github.com/CircuitVerse/cv-frontend-vue/assets/89861718/837ec6ce-52d4-40a2-96ef-b1517cd80793

- after the changes:

https://github.com/CircuitVerse/cv-frontend-vue/assets/89861718/ea26021b-8192-46a3-86af-6754b8f0c331


