### PR TITLE
Fix: Improved Navbar Project Name Interaction

### DIFF
--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -5,12 +5,10 @@
 
         <div id="bs-example-navbar-collapse-1" class="collapse navbar-collapse">
             <NavbarLinks :navbar-data="navbarData" />
-
-            <span
-                id="projectName"
-                class="projectName noSelect defaultCursor font-weight-bold"
-            >
-                {{ projectStore.getProjectName }}
+            <span id="projectName" class="projectName noSelect defaultCursor font-weight-bold">
+                <div class="projectNameTextArea">
+                    {{ projectStore.getProjectName }}
+                </div>
             </span>
             <User :user-data="userDropdownItems" />
         </div>

--- a/src/simulator/src/listeners.js
+++ b/src/simulator/src/listeners.js
@@ -75,6 +75,7 @@ export default function startListeners() {
     $('#projectName').on('click', () => {
         simulationArea.lastSelected = globalScope.root
         setTimeout(() => {
+            document.querySelector('#moduleProperty .maximize').click()
             document.getElementById('projname').select()
         }, 100)
     })

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -184,6 +184,11 @@ input[type='text']:focus {
     text-overflow: ellipsis;
 }
 
+.projectNameTextArea:hover {
+    cursor: pointer;
+    text-decoration-line: underline;
+}
+
 @media (max-width: 991px) {
     .projectName {
         visibility: hidden;


### PR DESCRIPTION
Fixes #289

#### Describe the changes you have made in this PR -

- Modified the styling of the `projectName` span in the Navbar to change the cursor to a pointer and underline the project name upon hovering.
- Adjusted the click listener on `projectName` to maximize the properties panel if it's minimized, indicating that the project name is now editable.

### Screenshots of the changes (If any) -

https://github.com/CircuitVerse/cv-frontend-vue/assets/89861718/44a1f4c6-edf1-44cf-a276-6044c321a643

