### PR TITLE
fix: last selected element label duplication fixed

### DIFF
--- a/src/components/Panels/PropertiesPanel/PropertiesPanel.vue
+++ b/src/components/Panels/PropertiesPanel/PropertiesPanel.vue
@@ -33,6 +33,9 @@ function showPropertiesPanel() {
     if (toRaw(propertiesPanelObj.value) == simulationArea.lastSelected) return
     prevPropertyObjSet(simulationArea.lastSelected)
     propertiesPanelObj.value = simulationArea.lastSelected
+    if(simulationArea.lastSelected.newElement) {
+        simulationArea.lastSelected.label = ""
+    }
     // there are 3 types of panel body for Properties Panel
     // depending upon which is last selected
     // 1. Properties Panel in Layout mode

--- a/src/simulator/src/engine.js
+++ b/src/simulator/src/engine.js
@@ -544,6 +544,9 @@ export function update(scope = globalScope, updateEverything = false) {
             simulationArea.lastSelected.objectType !== 'Wire'
         ) {
             // ideas: why show properties of project in Nodes but not wires?
+            if (simulationArea.lastSelected.newElement) {
+                simulationArea.lastSelected.label = '';
+            }
             showProperties(simulationArea.lastSelected)
         } else {
             // hideProperties();

--- a/src/simulator/src/engine.js
+++ b/src/simulator/src/engine.js
@@ -544,9 +544,6 @@ export function update(scope = globalScope, updateEverything = false) {
             simulationArea.lastSelected.objectType !== 'Wire'
         ) {
             // ideas: why show properties of project in Nodes but not wires?
-            if (simulationArea.lastSelected.newElement) {
-                simulationArea.lastSelected.label = '';
-            }
             showProperties(simulationArea.lastSelected)
         } else {
             // hideProperties();


### PR DESCRIPTION
Fixes #292 

#### Describe the changes you have made in this PR -

Added a check `if` element that is selected is new then set the label to `""` empty string

### Screenshots of the changes (If any) -

https://github.com/CircuitVerse/cv-frontend-vue/assets/91966855/b9d05eb8-7bc6-41e2-ba54-d65da6e80f59
