### PR TITLE
fix(clock): add missing help button

### DIFF
--- a/src/simulator/src/sequential/Clock.js
+++ b/src/simulator/src/sequential/Clock.js
@@ -88,6 +88,8 @@ export default class Clock extends CircuitElement {
 Clock.prototype.tooltipText = 'Clock'
 
 Clock.prototype.click = Clock.prototype.toggleState
+Clock.prototype.helplink =
+    'https://docs.circuitverse.org/#/chapter4/6sequentialelements?id=clock'
 Clock.prototype.objectType = 'Clock'
 Clock.prototype.propagationDelay = 0
 Clock.prototype.propagationDelayFixed = true


### PR DESCRIPTION
Fixes #299 

#### This pull request accounts for an inconsistency in the design of our user interface by putting the button that was missing in the **properties panel** for **clock** element. Except for the clock, other circuit elements have this button for redirecting users to specific topics in **circuitverse docs**.  Previously, the clock was the only circuit element that lacked a help button. This will help us maintain consistency in our system.
#### It was simply fixed by adding a *help link *in prototype of class **Clock** in file *clock.js*

### Screenshots of the changes 
![Screenshot 2024-04-30 104414](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/32c72744-073b-47b7-8751-d0c73bb224d8)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 