### PR TITLE
fix(ui): draggable panel issue fixed

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -5,7 +5,6 @@
     position: relative;
     top: 0;
     width: 100%;
-    z-index: 100;
 }
 .header {
     background: var(--bg-navbar);

--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -290,7 +290,6 @@ function isEmbed(): boolean {
     position: relative;
     overflow: hidden;
     padding-bottom: 2.5px;
-    z-index: 100;
 }
 
 #tabsBar.embed-tabbar {

--- a/src/simulator/src/drag.ts
+++ b/src/simulator/src/drag.ts
@@ -74,7 +74,7 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
 
     $(DragEl).on('mousedown', () => {
         $(`.draggable-panel:not(${DragEl})`).css('z-index', '99')
-        $(DragEl).css('z-index', '99')
+        $(DragEl).css('z-index', '100')
     })
 
     let panelElements = document.querySelectorAll(

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -578,7 +578,6 @@ div.icon img {
     /* height: 23.5px; */
     display: block;
     align-items: center;
-    z-index: 99;
     /* position: absolute;
     top: 47px; */
 }


### PR DESCRIPTION
Fixes #302 

#### In this pull request, I have resolved an issue with draggable panels not coming to the front when clicked if overlapped. The core of the problem was the z-index management of the panels, where previously all panels had similar stacking priorities. To address this, I modified the z-index values, setting the actively selected panel to a z-index of 100, while other unselected draggable panels are now set to a z-index of 99. This change ensures that the panel being interacted with by the user always takes precedence and appears on top, thus significantly improving the user interface interaction and overall usability of the application.

#### Also the issue of dropdown menu hiding behind tabs bar has been fixed.

### 
![Screenshot 2024-05-06 180231](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/4a2d2286-de3f-43f1-b016-0bbce23070eb)
