### PR TITLE
fix(UI): tabsbar dropdown button visibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "interactjs": "^1.10.17",
                 "jquery": "^3.6.0",
                 "pinia": "^2.0.14",
+                "resize-observer-polyfill": "^1.5.1",
                 "vue": "^3.2.25",
                 "vue-i18n": "^9.1.10",
                 "vue-router": "^4.0.15",
@@ -5753,6 +5754,11 @@
                 "lodash": "^4.17.14"
             }
         },
+        "node_modules/resize-observer-polyfill": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+            "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+        },
         "node_modules/resolve": {
             "version": "1.22.0",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -11155,6 +11161,11 @@
             "requires": {
                 "lodash": "^4.17.14"
             }
+        },
+        "resize-observer-polyfill": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+            "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         },
         "resolve": {
             "version": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "interactjs": "^1.10.17",
         "jquery": "^3.6.0",
         "pinia": "^2.0.14",
+        "resize-observer-polyfill": "^1.5.1",
         "vue": "^3.2.25",
         "vue-i18n": "^9.1.10",
         "vue-router": "^4.0.15",


### PR DESCRIPTION
Fixes #304 

#### This pull request fixes the issue of tabsbar dropdown button being visible even when tabs bar is not being overflown by ciruit buttons. This was creating a confusion (which i faced too) about the function of the dropdown button when the tabsbar isn't overflowing. For this, I added a V-if directive with computed property which checks whether the tabsbar has been overflown or not and conditionally renders the dropdown button on tabsbar. Now the dropdown button now only appears when necessary, improving the UI clarity and user experience.

#### I used two browser apis **mutationObserver** and **resizeObserver** for observing changes in size of tabsbar and checking overflow on insertion of new circuit buttons. Since **resizeObserver** is not supported in older browsers, i had to use a polyfill for it which i installed using **npm**.

### Impact
**User Experience:** Enhances user experience by preventing confusion about the purpose of the dropdown button when there is no overflow.
**Performance:** Observers are used efficiently to manage and trigger updates only on actual changes to the tabs bar, ensuring minimal performance impact.

**Testing:** Manual testing was performed to ensure that the dropdown button now only appears when the tabs bar is actually overflowing

![Screenshot 2024-05-08 183611](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/f6872ca0-3e62-47fa-a344-9a8749214747)
![Screenshot 2024-05-08 183934](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/5042c1e0-4cd3-413b-8278-1332ca2c6773)
