### PR TITLE
fix(bug): Properties Panel Freeze Upon Element Deletion in Simulation Area

### DIFF
--- a/src/components/Panels/PropertiesPanel/PropertiesPanel.vue
+++ b/src/components/Panels/PropertiesPanel/PropertiesPanel.vue
@@ -33,9 +33,6 @@ function showPropertiesPanel() {
     if (toRaw(propertiesPanelObj.value) == simulationArea.lastSelected) return
     prevPropertyObjSet(simulationArea.lastSelected)
     propertiesPanelObj.value = simulationArea.lastSelected
-    if(simulationArea.lastSelected.newElement) {
-        simulationArea.lastSelected.label = ""
-    }
     // there are 3 types of panel body for Properties Panel
     // depending upon which is last selected
     // 1. Properties Panel in Layout mode


### PR DESCRIPTION
Fixes #308 

#### This issue has been resolved by removing unnecessary code that caused the properties panel to freeze when an element was deleted in the simulation area. Previously, the code was checking if the last selected element was a new element or not, and upon deletion, when the last selected element became undefined, it caused errors. By removing this portion from the **showPropertiesPanel()** function, the properties panel now displays project properties instead of freezing upon element deletion, improving the overall user experience.

### Impact
#### 1. The properties panel now functions smoothly even after deleting elements in the simulation area.
#### 2. Users no longer experience freezing or unresponsiveness when interacting with the properties panel.