### PR TITLE
fix(UI): gates upper edge drawing issue

### DIFF
--- a/src/simulator/src/canvasApi.js
+++ b/src/simulator/src/canvasApi.js
@@ -240,7 +240,10 @@ export function moveTo(ctx, x1, y1, xx, yy, dir, bypass = false) {
     xx *= globalScope.scale
     yy *= globalScope.scale
     if (bypass) {
-        ctx.moveTo(xx + globalScope.ox + newX, yy + globalScope.oy + newY)
+        ctx.moveTo(
+            Math.round(xx + globalScope.ox + newX),
+            Math.round(yy + globalScope.oy + newY)
+        )
     } else {
         ctx.moveTo(
             Math.round(xx + globalScope.ox + newX - correction) + correction,


### PR DESCRIPTION
### Description

#### Issue
This pull request addresses issue #310 :  Corner Triangular Edge Display Issue Of Logic Gates.

#### Problem
The issue arises due to the upper edges of circuit elements, particularly gates with triangular corners like OR Gate, NOR Gate, X-OR Gate, etc., being slightly distorted on the default zoom level. This distortion affects the UI negatively, causing an inconsistent appearance.

#### Root Cause
Upon investigating, it was found that the distortion occurs during the drawing of the gates. While drawing curves, the `Math.round()` function is correctly used to round off decimal numbers. However, when moving the canvas context (ctx), `Math.round()` is not applied to the moving coordinates. As a result, when the `ctx.closePath()` method is called, the presence of decimal numbers, particularly .5 in both x and y coordinates, causes the upper edge distortion.

#### Solution
To resolve this issue, `Math.round()` is applied to the values before moving the ctx. This ensures that the coordinates are always rounded to whole numbers, resulting in smooth curve creation for the gates drawing.

#### Impact
Implementing this solution ensures consistent and distortion-free rendering of the circuit elements' upper edges, enhancing the UI experience for users.

### Changes Made

- Applied `Math.round()` to coordinates before moving the canvas context to ensure whole number values.
- Tested the changes thoroughly to ensure they resolve the issue without introducing any other problems.
  
### Testing

Manual Testing was done in order to validate the changes.

### Screenshots
#### Before
![Screenshot 2024-05-13 174822](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/09e89bdb-a99b-4f6d-8c54-414dd15f8f5f)
![Screenshot 2024-05-13 174850](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/11e4410d-d617-4d0f-907e-d4efa4661e76)
![Screenshot 2024-05-13 203220](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/1aeff081-d871-436f-a32c-95bf15f3a43d)

#### After (for every positions and scales)
![Screenshot 2024-05-13 174906](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/9e844a2f-504a-42fb-a5b7-1fb21a224a3b)
![Screenshot 2024-05-13 221921](https://github.com/CircuitVerse/cv-frontend-vue/assets/127468609/622a6b45-c35d-4111-96e8-bd37200a4de8)
