### PR TITLE
Fix Clock Settings Functionality and Improve UI

### DIFF
--- a/src/components/Panels/PropertiesPanel/ModuleProperty/ProjectProperty/ProjectProperty.vue
+++ b/src/components/Panels/PropertiesPanel/ModuleProperty/ProjectProperty/ProjectProperty.vue
@@ -42,7 +42,9 @@
             <input
                 type="checkbox"
                 class="objectPropertyAttributeChecked"
-                name="changeClockEnable" />
+                name="changeClockEnable"
+                checked
+            />
             <span class="slider"></span
         ></label>
     </p>

--- a/src/components/Panels/Shared/InputGroups.vue
+++ b/src/components/Panels/Shared/InputGroups.vue
@@ -79,3 +79,17 @@ function decreaseValue() {
     ele.dispatchEvent(e)
 }
 </script>
+
+<style scoped>
+/* Hide spinners for numeric input' */
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+input[type=number]{
+    -moz-appearance: textfield;
+}
+</style>

--- a/src/simulator/src/circuit.ts
+++ b/src/simulator/src/circuit.ts
@@ -48,6 +48,11 @@ export const circuitProperty = {
     changeClockEnable,
     changeInputSize,
     changeLightMode,
+    changeClockTime
+}
+
+function changeClockTime(t: number) {
+    simulationArea.changeClockTime(t)
 }
 
 export let scopeList: { [key: string]: Scope } = {}


### PR DESCRIPTION
### Description:

#### This PR resolves an issue where the clock settings in CircuitVerse's Vue Simulator were not functioning correctly. Regardless of the clock time set, the clock always oscillated with a period of 500ms. This fix ensures that the clock now operates according to the user's specified time.

#### Additionally, the clock wasn't enabled by default, and a scroll bar appeared on the clock time display, leading to poor UI. These issues have been fixed by:

####  - Integrating the function to change the clock time (previously implemented in simulatorArea) into circuitProperties.
#### - Removing the scroll bar on the clock time display using basic CSS..
#### - Enabling the clock by default using html attribute 'checked'.

### Testing:
#### Manual testing was conducted to verify that the clock functions as expected and the UI improvements are effective.

### Screencasts

#### Before
[Screencast from 2024-10-03 18-28-21.webm](https://github.com/user-attachments/assets/e2f7250b-bee7-4422-b17b-4a22ceb61c7b)

#### After
[Screencast from 2024-10-03 18-29-20.webm](https://github.com/user-attachments/assets/378db167-8621-40fd-b2fc-ab7a63de0dc5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced project property input with responsive circuit name updates.
	- Added functionality to change clock time in the simulation area.

- **Bug Fixes**
	- Default state of the "Clock Enabled" checkbox is now checked.

- **Style**
	- Updated numeric input fields to hide default spinners for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->