### PR TITLE
fix: correct typo in 'sign in' text

### DIFF
--- a/src/components/Navbar/User/UserMenu.vue
+++ b/src/components/Navbar/User/UserMenu.vue
@@ -47,7 +47,7 @@
                       <v-list-item
                           @click.stop="signin"
                           prepend-icon="mdi-login"
-                          title="Sing In"
+                          title="Sign In"
                           value="sign_in"
                       ></v-list-item>
                       <v-list-item


### PR DESCRIPTION
Fixes #390
#### Describe the changes you have made in this PR -
The typo has been corrected from "sing in" to "sign in."

Preview
![Screenshot 2024-12-04 180405](https://github.com/user-attachments/assets/18019ecc-a01f-44b6-803d-530111ade838)


## Issue Link
Closes #390


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the spelling of "Sign In" in the User Menu for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->