### PR TITLE
Changes behavior for simultaneous async preset and reset high.

### DIFF
--- a/src/simulator/src/sequential/DflipFlop.js
+++ b/src/simulator/src/sequential/DflipFlop.js
@@ -61,8 +61,10 @@ export default class DflipFlop extends CircuitElement {
      * and input of the clock. We flip the bits to find qInvOutput
      */
     resolve() {
-        if (this.reset.value == 1) {
-            this.masterState = this.slaveState = this.preset.value || 0
+        if (this.reset.value == 1 && this.preset.value == 0) {
+            this.masterState = this.slaveState = 0;
+        } else if(this.preset.value == 1 && this.reset.value == 0){
+            this.masterState = this.slaveState = 1; //accomodates better for race condition. Keeps the state in previous state if both async preset and reset are 1 just like how S=1 and R=1 case is being handled currently
         } else if (this.en.value == 0) {
             this.prevClockState = this.clockInp.value
         } else if (this.en.value == 1 || this.en.connections.length == 0) {

--- a/src/simulator/src/sequential/JKflipFlop.js
+++ b/src/simulator/src/sequential/JKflipFlop.js
@@ -66,8 +66,10 @@ export default class JKflipFlop extends CircuitElement {
      * in the clock. masterState = this.J when no change in clock.
      */
     resolve() {
-        if (this.reset.value == 1) {
-            this.masterState = this.slaveState = this.preset.value || 0
+        if (this.reset.value == 1 && this.preset.value == 0) {
+            this.masterState = this.slaveState = 0;
+        } else if(this.preset.value == 1 && this.reset.value == 0){
+            this.masterState = this.slaveState = 1; //accomodates better for race condition. Keeps the state in previous state if both async preset and reset are 1 just like how S=1 and R=1 case is being handled currently
         } else if (this.en.value == 0) {
             this.prevClockState = this.clockInp.value
         } else if (this.en.value == 1 || this.en.connections.length == 0) {

--- a/src/simulator/src/sequential/SRflipFlop.js
+++ b/src/simulator/src/sequential/SRflipFlop.js
@@ -54,8 +54,12 @@ export default class SRflipFlop extends CircuitElement {
      * set this.state to value S.
      */
     resolve() {
-        if (this.reset.value == 1) {
-            this.state = this.preset.value || 0
+        // if (this.reset.value == 1) {
+        //     this.state = this.preset.value || 0 possibility of reset =1 and preset = 1 which leads to race
+        if (this.reset.value == 1 && this.preset.value == 0) {
+            this.state = 0;
+        } else if(this.preset.value == 1 && this.reset.value == 0){
+            this.state = 1; //accomodates better for race condition. Keeps the state in previous state if both async preset and reset are 1 just like how S=1 and R=1 case is being handled currently
         } else if (
             (this.en.value == 1 || this.en.connections == 0) &&
             this.S.value ^ this.R.value

--- a/src/simulator/src/sequential/TflipFlop.js
+++ b/src/simulator/src/sequential/TflipFlop.js
@@ -69,9 +69,10 @@ export default class TflipFlop extends CircuitElement {
      * We flip the bits to find qInvOutput
      */
     resolve() {
-        if (this.reset.value == 1) {
-            // if reset bit is set
-            this.masterState = this.slaveState = this.preset.value || 0
+        if (this.reset.value == 1 && this.preset.value == 0) {
+            this.masterState = this.slaveState = 0;
+        } else if(this.preset.value == 1 && this.reset.value == 0){
+            this.masterState = this.slaveState = 1; //accomodates better for race condition. Keeps the state in previous state if both async preset and reset are 1 just like how S=1 and R=1 case is being handled currently
         } else if (this.en.value == 0) {
             // if enabled bit is 0
             this.prevClockState = this.clockInp.value


### PR DESCRIPTION
The changes in the code help better to moderate the state behavior during Race condition.

Fixes # When both async preset and reset are high, the state is set to previous state instead of toggling to high.

#### Describe the changes you have made in this PR -

### Screenshots of the changes (If any) -
![image](https://github.com/user-attachments/assets/d4f523d5-9cb2-4926-818e-6105a9f19bae)
above is changes for dff, similar changes have been all made in codes of all flip flops.



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of asynchronous reset and preset conditions across various flip-flop classes (D, JK, SR, T).
	- Improved robustness against race conditions in state management.

- **Bug Fixes**
	- Refined logic for state updates to ensure correct behavior when both preset and reset are active.

- **Documentation**
	- Updated comments for clarity on the new behavior of flip-flops under specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->