### PR TITLE
Correct Typo in 'Sing In' to 'Sign In' in User Menu

### DIFF
--- a/src/components/Navbar/User/UserMenu.vue
+++ b/src/components/Navbar/User/UserMenu.vue
@@ -47,7 +47,7 @@
                       <v-list-item
                           @click.stop="signin"
                           prepend-icon="mdi-login"
-                          title="Sing In"
+                          title="Sign In"
                           value="sign_in"
                       ></v-list-item>
                       <v-list-item


### PR DESCRIPTION
Fixes #390

Describe the changes you have made in this PR:
Fixed the typo in the sign-in button text from "Sing In" to "Sign In" in the avatar-menu component.
Screenshots of the changes :
![Capture](https://github.com/user-attachments/assets/1cfd6ef2-bacb-447d-a804-556365b8bbf0)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the text for the "Sign In" option in the user menu from "Sing In" to "Sign In".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->