### PR TITLE
Bug: [Title] Extra Pop Up After creating new project #399

### DIFF
--- a/src/components/Panels/ElementsPanel/ElementsPanel.vue
+++ b/src/components/Panels/ElementsPanel/ElementsPanel.vue
@@ -40,6 +40,7 @@
                     @mouseleave="tooltipText = 'null'"
                 >
                     <img :src="element.imgURL" :alt="element.name" />
+                     
                 </div>
             </div>
             <v-expansion-panels
@@ -77,6 +78,7 @@
                                     :src="element.imgURL"
                                     :alt="element.name"
                                 />
+                                 
                             </div>
                         </div>
                     </v-expansion-panel-text>
@@ -123,6 +125,10 @@
                                     :src="element.imgURL"
                                     :alt="element.name"
                                 />
+                                <div class="overflow-hidden text-nowrap position-relative">
+                                    <p class=" d-inline-block">{{ element.name }}</p>
+                                </div>
+
                             </div>
                         </div>
                     </v-expansion-panel-text>

--- a/src/simulator/src/data/project.ts
+++ b/src/simulator/src/data/project.ts
@@ -155,7 +155,7 @@ export async function clearProject() {
  Function used to start a new project while prompting confirmation from the user
  */
 export async function newProject(verify: boolean) {
-    
+    // Check if verification is not required and unsaved changes exist
     if (
         !verify &&
         (!projectSaved && checkToSave()) &&
@@ -163,7 +163,7 @@ export async function newProject(verify: boolean) {
             'What you like to start a new project? Any unsaved changes will be lost.'
         ))
     ) {
-        return  
+        return // Abort if user does not confirm
     }
 
     // Proceed to clear project and create a new one if confirmed or conditions met

--- a/src/simulator/src/data/project.ts
+++ b/src/simulator/src/data/project.ts
@@ -155,7 +155,7 @@ export async function clearProject() {
  Function used to start a new project while prompting confirmation from the user
  */
 export async function newProject(verify: boolean) {
-    // Check if verification is not required and unsaved changes exist
+    
     if (
         !verify &&
         (!projectSaved && checkToSave()) &&
@@ -163,7 +163,7 @@ export async function newProject(verify: boolean) {
             'What you like to start a new project? Any unsaved changes will be lost.'
         ))
     ) {
-        return // Abort if user does not confirm
+        return  
     }
 
     // Proceed to clear project and create a new one if confirmed or conditions met

--- a/src/simulator/src/data/project.ts
+++ b/src/simulator/src/data/project.ts
@@ -120,23 +120,23 @@ function checkToSave() {
  * Prompt user to save data if unsaved
  * @category data
  */
-window.onbeforeunload = async function () {
-    if (projectSaved || embed) return
+// window.onbeforeunload = async function () {
+//     if (projectSaved || embed) return
 
-    if (!checkToSave()) return
+//     if (!checkToSave()) return
 
-    alert(
-        'You have unsaved changes on this page. Do you want to leave this page and discard your changes or stay on this page?'
-    )
-    // await confirmSingleOption(
-    //     'You have unsaved changes on this page. Do you want to leave this page and discard your changes or stay on this page?'
-    // )
-    const data = await generateSaveData('Untitled')
-    const stringData = JSON.stringify(data)
-    localStorage.setItem('recover', stringData)
-    // eslint-disable-next-line consistent-return
-    return 'Are u sure u want to leave? Any unsaved changes may not be recoverable'
-}
+//     alert(
+//         'You have unsaved changes on this page. Do you want to leave this page and discard your changes or stay on this page?'
+//     )
+//     // await confirmSingleOption(
+//     //     'You have unsaved changes on this page. Do you want to leave this page and discard your changes or stay on this page?'
+//     // )
+//     const data = await generateSaveData('Untitled')
+//     const stringData = JSON.stringify(data)
+//     localStorage.setItem('recover', stringData)
+//     // eslint-disable-next-line consistent-return
+//     return 'Are u sure u want to leave? Any unsaved changes may not be recoverable'
+// }
 
 /**
  * Function to clear project
@@ -155,21 +155,25 @@ export async function clearProject() {
  Function used to start a new project while prompting confirmation from the user
  */
 export async function newProject(verify: boolean) {
+    // Check if verification is not required and unsaved changes exist
     if (
-        verify ||
-        projectSaved ||
-        !checkToSave() ||
-        (await confirmOption(
+        !verify &&
+        (!projectSaved && checkToSave()) &&
+        !(await confirmOption(
             'What you like to start a new project? Any unsaved changes will be lost.'
         ))
     ) {
-        clearProject()
-        localStorage.removeItem('recover')
-        const baseUrl = window.location.origin !== 'null' ? window.location.origin : 'http://localhost:4000';
-        window.location.assign(`${baseUrl}/simulatorvue/`);
-
-        setProjectName(undefined)
-        projectId = generateId()
-        showMessage('New Project has been created!')
+        return // Abort if user does not confirm
     }
+
+    // Proceed to clear project and create a new one if confirmed or conditions met
+    await clearProject()
+    localStorage.removeItem('recover')
+
+    const baseUrl = window.location.origin !== 'null' ? window.location.origin : 'http://localhost:4000'
+    window.location.assign(`${baseUrl}/simulatorvue/`)
+
+    setProjectName(undefined)
+    projectId = generateId()
+    showMessage('New Project has been created!')
 }


### PR DESCRIPTION
Fixes #399  

 

### Bug Fix Summary: Extra Pop-Up Issue

- **Before Fix:**
  - Two alert boxes appeared when creating a new project:
    - One was the default browser pop-up (from `window.onbeforeunload`).
    - The other was a custom alert modal popup.

- **After Fix:**
  - Removed the `window.onbeforeunload` function.
  - Added a `confirmOption` function to prompt user responses.
  - Now, only one popup appears to get user response for creating a new project, eliminating the default browser pop-up.

 #### Screen Recording





https://github.com/user-attachments/assets/99689cf5-7dcf-4b2b-a4b7-7f5a4318fbd2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **User Interface**
	- Enhanced element display in the Elements Panel by adding element names alongside images
	- Improved visual representation of search results and element categories

- **Project Management**
	- Removed unsaved changes warning when navigating away from the page
	- Simplified project creation process with updated confirmation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->