### PR TITLE
Bump-Bootstrap 4.6.2 - 5.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0",
             "hasInstallScript": true,
             "dependencies": {
-                "@fortawesome/fontawesome-free": "^6.5.1",
+                "@fortawesome/fontawesome-free": "^6.7.2",
                 "@mdi/font": "5.9.55",
                 "@tiptap/core": "^2.0.3",
                 "@tiptap/extension-character-count": "^2.0.3",
@@ -51,7 +51,7 @@
                 "jsdoc": "^4.0.3",
                 "jsdom": "^24.1.1",
                 "prettier": "2.6.2",
-                "sass": "^1.77.6",
+                "sass": "^1.83.4",
                 "typescript": "^4.5.4",
                 "vite": "^2.9.18",
                 "vite-plugin-vuetify": "^1.0.0-alpha.0",
@@ -955,10 +955,10 @@
             "integrity": "sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw=="
         },
         "node_modules/@fortawesome/fontawesome-free": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
-            "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==",
-            "hasInstallScript": true,
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
+            "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
+            "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
             "engines": {
                 "node": ">=6"
             }
@@ -1352,6 +1352,330 @@
             "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
             "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
             "dev": true
+        },
+        "node_modules/@parcel/watcher": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.0.tgz",
+            "integrity": "sha512-i0GV1yJnm2n3Yq1qw6QrUrd/LI9bE8WEBOTtOkpCXHHdyN3TAGgqAK/DAT05z4fq2x04cARXt2pDmjWjL92iTQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "detect-libc": "^1.0.3",
+                "is-glob": "^4.0.3",
+                "micromatch": "^4.0.5",
+                "node-addon-api": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher-android-arm64": "2.5.0",
+                "@parcel/watcher-darwin-arm64": "2.5.0",
+                "@parcel/watcher-darwin-x64": "2.5.0",
+                "@parcel/watcher-freebsd-x64": "2.5.0",
+                "@parcel/watcher-linux-arm-glibc": "2.5.0",
+                "@parcel/watcher-linux-arm-musl": "2.5.0",
+                "@parcel/watcher-linux-arm64-glibc": "2.5.0",
+                "@parcel/watcher-linux-arm64-musl": "2.5.0",
+                "@parcel/watcher-linux-x64-glibc": "2.5.0",
+                "@parcel/watcher-linux-x64-musl": "2.5.0",
+                "@parcel/watcher-win32-arm64": "2.5.0",
+                "@parcel/watcher-win32-ia32": "2.5.0",
+                "@parcel/watcher-win32-x64": "2.5.0"
+            }
+        },
+        "node_modules/@parcel/watcher-android-arm64": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.0.tgz",
+            "integrity": "sha512-qlX4eS28bUcQCdribHkg/herLe+0A9RyYC+mm2PXpncit8z5b3nSqGVzMNR3CmtAOgRutiZ02eIJJgP/b1iEFQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-arm64": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.0.tgz",
+            "integrity": "sha512-hyZ3TANnzGfLpRA2s/4U1kbw2ZI4qGxaRJbBH2DCSREFfubMswheh8TeiC1sGZ3z2jUf3s37P0BBlrD3sjVTUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-darwin-x64": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.0.tgz",
+            "integrity": "sha512-9rhlwd78saKf18fT869/poydQK8YqlU26TMiNg7AIu7eBp9adqbJZqmdFOsbZ5cnLp5XvRo9wcFmNHgHdWaGYA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-freebsd-x64": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.0.tgz",
+            "integrity": "sha512-syvfhZzyM8kErg3VF0xpV8dixJ+RzbUaaGaeb7uDuz0D3FK97/mZ5AJQ3XNnDsXX7KkFNtyQyFrXZzQIcN49Tw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-glibc": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.0.tgz",
+            "integrity": "sha512-0VQY1K35DQET3dVYWpOaPFecqOT9dbuCfzjxoQyif1Wc574t3kOSkKevULddcR9znz1TcklCE7Ht6NIxjvTqLA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm-musl": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.0.tgz",
+            "integrity": "sha512-6uHywSIzz8+vi2lAzFeltnYbdHsDm3iIB57d4g5oaB9vKwjb6N6dRIgZMujw4nm5r6v9/BQH0noq6DzHrqr2pA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-glibc": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.0.tgz",
+            "integrity": "sha512-BfNjXwZKxBy4WibDb/LDCriWSKLz+jJRL3cM/DllnHH5QUyoiUNEp3GmL80ZqxeumoADfCCP19+qiYiC8gUBjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-arm64-musl": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.0.tgz",
+            "integrity": "sha512-S1qARKOphxfiBEkwLUbHjCY9BWPdWnW9j7f7Hb2jPplu8UZ3nes7zpPOW9bkLbHRvWM0WDTsjdOTUgW0xLBN1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-glibc": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.0.tgz",
+            "integrity": "sha512-d9AOkusyXARkFD66S6zlGXyzx5RvY+chTP9Jp0ypSTC9d4lzyRs9ovGf/80VCxjKddcUvnsGwCHWuF2EoPgWjw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-linux-x64-musl": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.0.tgz",
+            "integrity": "sha512-iqOC+GoTDoFyk/VYSFHwjHhYrk8bljW6zOhPuhi5t9ulqiYq1togGJB5e3PwYVFFfeVgc6pbz3JdQyDoBszVaA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-arm64": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.0.tgz",
+            "integrity": "sha512-twtft1d+JRNkM5YbmexfcH/N4znDtjgysFaV9zvZmmJezQsKpkfLYJ+JFV3uygugK6AtIM2oADPkB2AdhBrNig==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-ia32": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.0.tgz",
+            "integrity": "sha512-+rgpsNRKwo8A53elqbbHXdOMtY/tAtTzManTWShB5Kk54N8Q9mzNWV7tV+IbGueCbcj826MfWGU3mprWtuf1TA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher-win32-x64": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.0.tgz",
+            "integrity": "sha512-lPrxve92zEHdgeff3aiu4gDOIt4u7sJYha6wbdEZDCDUhtjTsOMiaJzG5lMY4GkWH8p0fMmO2Ppq5G5XXG+DQw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/@parcel/watcher/node_modules/detect-libc": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+            "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "bin": {
+                "detect-libc": "bin/detect-libc.js"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -5152,10 +5476,11 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
-            "integrity": "sha512-Ju0+lEMyzMVZarkTn/gqRpdqd5dOPaz1mCZ0SH3JV6iFw81PldE/PEB1hWVEA288HPt4WXW8O7AWxB10M+03QQ==",
-            "devOptional": true
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
+            "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
@@ -6476,6 +6801,14 @@
             "dev": true,
             "peer": true
         },
+        "node_modules/node-addon-api": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+            "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true
+        },
         "node_modules/node-fetch": {
             "version": "2.7.0",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -7660,13 +7993,14 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.77.6",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.6.tgz",
-            "integrity": "sha512-ByXE1oLD79GVq9Ht1PeHWCPMPB8XHpBuz1r85oByKHjZY6qV6rWnQovQzXJXuQ/XyE1Oj3iPk3lo28uzaRA2/Q==",
+            "version": "1.83.4",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.4.tgz",
+            "integrity": "sha512-B1bozCeNQiOgDcLd33e2Cs2U60wZwjUUXzh900ZyQF5qUasvMdDZYbQ566LJu7cqR+sAHlAfO6RMkaID5s6qpA==",
             "devOptional": true,
+            "license": "MIT",
             "dependencies": {
-                "chokidar": ">=3.0.0 <4.0.0",
-                "immutable": "^4.0.0",
+                "chokidar": "^4.0.0",
+                "immutable": "^5.0.2",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "bin": {
@@ -7674,6 +8008,39 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            },
+            "optionalDependencies": {
+                "@parcel/watcher": "^2.4.1"
+            }
+        },
+        "node_modules/sass/node_modules/chokidar": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+            "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "readdirp": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 14.16.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/sass/node_modules/readdirp": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.1.tgz",
+            "integrity": "sha512-h80JrZu/MHUZCyHu5ciuoI0+WxsCxzxJTILn6Fs8rxSnFPh+UVHYfeIxK1nVGugMqkfC4vJcBOYbkfkwYK0+gw==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.18.0"
+            },
+            "funding": {
+                "type": "individual",
+                "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/saxes": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@tiptap/extension-underline": "^2.0.3",
                 "@tiptap/starter-kit": "^2.0.3",
                 "@tiptap/vue-3": "^2.0.3",
-                "bootstrap": "^4.6.1",
+                "bootstrap": "^5.3.3",
                 "canvas-to-svg": "^1.0.3",
                 "codemirror": "^5.65.1",
                 "codemirror-editor-vue3": "^2.1.7",
@@ -1361,10 +1361,10 @@
             }
         },
         "node_modules/@popperjs/core": {
-            "name": "@sxzz/popperjs-es",
-            "version": "2.11.7",
-            "resolved": "https://registry.npmjs.org/@sxzz/popperjs-es/-/popperjs-es-2.11.7.tgz",
-            "integrity": "sha512-Ccy0NlLkzr0Ex2FKvh2X+OyERHXJ88XJ1MXtsI9y9fGexlaXaVTPzBCRBwIxFkORuOb+uBqeu+RqnpgYTEZRUQ==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "license": "MIT",
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -2945,9 +2945,9 @@
             "dev": true
         },
         "node_modules/bootstrap": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-            "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
             "funding": [
                 {
                     "type": "github",
@@ -2958,9 +2958,9 @@
                     "url": "https://opencollective.com/bootstrap"
                 }
             ],
+            "license": "MIT",
             "peerDependencies": {
-                "jquery": "1.9.1 - 3",
-                "popper.js": "^1.16.1"
+                "@popperjs/core": "^2.11.8"
             }
         },
         "node_modules/brace-expansion": {
@@ -6888,17 +6888,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/popper.js": {
-            "version": "1.16.1",
-            "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-            "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-            "peer": true,
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/popperjs"
             }
         },
         "node_modules/postcss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,12 +1028,13 @@
             }
         },
         "node_modules/@intlify/core-base": {
-            "version": "9.13.1",
-            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.13.1.tgz",
-            "integrity": "sha512-+bcQRkJO9pcX8d0gel9ZNfrzU22sZFSA0WVhfXrf5jdJOS24a+Bp8pozuS9sBI9Hk/tGz83pgKfmqcn/Ci7/8w==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.2.tgz",
+            "integrity": "sha512-DZyQ4Hk22sC81MP4qiCDuU+LdaYW91A6lCjq8AWPvY3+mGMzhGDfOCzvyR6YBQxtlPjFqMoFk9ylnNYRAQwXtQ==",
+            "license": "MIT",
             "dependencies": {
-                "@intlify/message-compiler": "9.13.1",
-                "@intlify/shared": "9.13.1"
+                "@intlify/message-compiler": "9.14.2",
+                "@intlify/shared": "9.14.2"
             },
             "engines": {
                 "node": ">= 16"
@@ -1043,11 +1044,12 @@
             }
         },
         "node_modules/@intlify/message-compiler": {
-            "version": "9.13.1",
-            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.13.1.tgz",
-            "integrity": "sha512-SKsVa4ajYGBVm7sHMXd5qX70O2XXjm55zdZB3VeMFCvQyvLew/dLvq3MqnaIsTMF1VkkOb9Ttr6tHcMlyPDL9w==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.2.tgz",
+            "integrity": "sha512-YsKKuV4Qv4wrLNsvgWbTf0E40uRv+Qiw1BeLQ0LAxifQuhiMe+hfTIzOMdWj/ZpnTDj4RSZtkXjJM7JDiiB5LQ==",
+            "license": "MIT",
             "dependencies": {
-                "@intlify/shared": "9.13.1",
+                "@intlify/shared": "9.14.2",
                 "source-map-js": "^1.0.2"
             },
             "engines": {
@@ -1058,9 +1060,10 @@
             }
         },
         "node_modules/@intlify/shared": {
-            "version": "9.13.1",
-            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.13.1.tgz",
-            "integrity": "sha512-u3b6BKGhE6j/JeRU6C/RL2FgyJfy6LakbtfeVF8fJXURpZZTzfh3e05J0bu0XPw447Q6/WUp3C4ajv4TMS4YsQ==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.2.tgz",
+            "integrity": "sha512-uRAHAxYPeF+G5DBIboKpPgC/Waecd4Jz8ihtkpJQD5ycb5PwXp0k/+hBGl5dAjwF7w+l74kz/PKA8r8OK//RUw==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 16"
             },
@@ -1390,208 +1393,266 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.20.0.tgz",
-            "integrity": "sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.30.1.tgz",
+            "integrity": "sha512-pSWY+EVt3rJ9fQ3IqlrEUtXh3cGqGtPDH1FQlNZehO2yYxCHEX1SPsz1M//NXwYfbTlcKr9WObLnJX9FsS9K1Q==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.20.0.tgz",
-            "integrity": "sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.30.1.tgz",
+            "integrity": "sha512-/NA2qXxE3D/BRjOJM8wQblmArQq1YoBVJjrjoTSBS09jgUisq7bqxNHJ8kjCHeV21W/9WDGwJEWSN0KQ2mtD/w==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "android"
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.20.0.tgz",
-            "integrity": "sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.30.1.tgz",
+            "integrity": "sha512-r7FQIXD7gB0WJ5mokTUgUWPl0eYIH0wnxqeSAhuIwvnnpjdVB8cRRClyKLQr7lgzjctkbp5KmswWszlwYln03Q==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.20.0.tgz",
-            "integrity": "sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.30.1.tgz",
+            "integrity": "sha512-x78BavIwSH6sqfP2xeI1hd1GpHL8J4W2BXcVM/5KYKoAD3nNsfitQhvWSw+TFtQTLZ9OmlF+FEInEHyubut2OA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "darwin"
             ]
         },
+        "node_modules/@rollup/rollup-freebsd-arm64": {
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.30.1.tgz",
+            "integrity": "sha512-HYTlUAjbO1z8ywxsDFWADfTRfTIIy/oUlfIDmlHYmjUP2QRDTzBuWXc9O4CXM+bo9qfiCclmHk1x4ogBjOUpUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-freebsd-x64": {
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.30.1.tgz",
+            "integrity": "sha512-1MEdGqogQLccphhX5myCJqeGNYTNcmTyaic9S7CG3JhwuIByJ7J05vGbZxsizQthP1xpVx7kd3o31eOogfEirw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ]
+        },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.20.0.tgz",
-            "integrity": "sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.30.1.tgz",
+            "integrity": "sha512-PaMRNBSqCx7K3Wc9QZkFx5+CX27WFpAMxJNiYGAXfmMIKC7jstlr32UhTgK6T07OtqR+wYlWm9IxzennjnvdJg==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.20.0.tgz",
-            "integrity": "sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.30.1.tgz",
+            "integrity": "sha512-B8Rcyj9AV7ZlEFqvB5BubG5iO6ANDsRKlhIxySXcF1axXYUyqwBok+XZPgIYGBgs7LDXfWfifxhw0Ik57T0Yug==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.20.0.tgz",
-            "integrity": "sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.30.1.tgz",
+            "integrity": "sha512-hqVyueGxAj3cBKrAI4aFHLV+h0Lv5VgWZs9CUGqr1z0fZtlADVV1YPOij6AhcK5An33EXaxnDLmJdQikcn5NEw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.20.0.tgz",
-            "integrity": "sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.30.1.tgz",
+            "integrity": "sha512-i4Ab2vnvS1AE1PyOIGp2kXni69gU2DAUVt6FSXeIqUCPIR3ZlheMW3oP2JkukDfu3PsexYRbOiJrY+yVNSk9oA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.30.1.tgz",
+            "integrity": "sha512-fARcF5g296snX0oLGkVxPmysetwUk2zmHcca+e9ObOovBR++9ZPOhqFUM61UUZ2EYpXVPN1redgqVoBB34nTpQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.20.0.tgz",
-            "integrity": "sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.30.1.tgz",
+            "integrity": "sha512-GLrZraoO3wVT4uFXh67ElpwQY0DIygxdv0BNW9Hkm3X34wu+BkqrDrkcsIapAY+N2ATEbvak0XQ9gxZtCIA5Rw==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.20.0.tgz",
-            "integrity": "sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.30.1.tgz",
+            "integrity": "sha512-0WKLaAUUHKBtll0wvOmh6yh3S0wSU9+yas923JIChfxOaaBarmb/lBKPF0w/+jTVozFnOXJeRGZ8NvOxvk/jcw==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.20.0.tgz",
-            "integrity": "sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.30.1.tgz",
+            "integrity": "sha512-GWFs97Ruxo5Bt+cvVTQkOJ6TIx0xJDD/bMAOXWJg8TCSTEK8RnFeOeiFTxKniTc4vMIaWvCplMAFBt9miGxgkA==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.20.0.tgz",
-            "integrity": "sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.30.1.tgz",
+            "integrity": "sha512-UtgGb7QGgXDIO+tqqJ5oZRGHsDLO8SlpE4MhqpY9Llpzi5rJMvrK6ZGhsRCST2abZdBqIBeXW6WPD5fGK5SDwg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.20.0.tgz",
-            "integrity": "sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.30.1.tgz",
+            "integrity": "sha512-V9U8Ey2UqmQsBT+xTOeMzPzwDzyXmnAoO4edZhL7INkwQcaW1Ckv3WJX3qrrp/VHaDkEWIBWhRwP47r8cdrOow==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.20.0.tgz",
-            "integrity": "sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.30.1.tgz",
+            "integrity": "sha512-WabtHWiPaFF47W3PkHnjbmWawnX/aE57K47ZDT1BXTS5GgrBUEpvOzq0FI0V/UYzQJgdb8XlhVNH8/fwV8xDjw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.20.0.tgz",
-            "integrity": "sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.30.1.tgz",
+            "integrity": "sha512-pxHAU+Zv39hLUTdQQHUVHf4P+0C47y/ZloorHpzs2SXMRqeAWmGghzAhfOlzFHHwjvgokdFAhC4V+6kC1lRRfw==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.20.0.tgz",
-            "integrity": "sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.30.1.tgz",
+            "integrity": "sha512-D6qjsXGcvhTjv0kI4fU8tUuBDF/Ueee4SVX79VfNDXZa64TfCW1Slkb6Z7O1p7vflqZjcmOVdZlqf8gvJxc6og==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -2048,9 +2109,10 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "license": "MIT"
         },
         "node_modules/@types/jquery": {
             "version": "3.5.30",
@@ -2547,163 +2609,178 @@
             }
         },
         "node_modules/@webassemblyjs/ast": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-            "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+            "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/helper-numbers": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+                "@webassemblyjs/helper-numbers": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
             }
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+            "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true,
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+            "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-            "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+            "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true,
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+            "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+                "@webassemblyjs/helper-api-error": "1.13.2",
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+            "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true,
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-            "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+            "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-buffer": "1.12.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/wasm-gen": "1.12.1"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/wasm-gen": "1.14.1"
             }
         },
         "node_modules/@webassemblyjs/ieee754": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+            "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@xtuc/ieee754": "^1.2.0"
             }
         },
         "node_modules/@webassemblyjs/leb128": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+            "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "@xtuc/long": "4.2.2"
             }
         },
         "node_modules/@webassemblyjs/utf8": {
-            "version": "1.11.6",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==",
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+            "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-            "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+            "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-buffer": "1.12.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/helper-wasm-section": "1.12.1",
-                "@webassemblyjs/wasm-gen": "1.12.1",
-                "@webassemblyjs/wasm-opt": "1.12.1",
-                "@webassemblyjs/wasm-parser": "1.12.1",
-                "@webassemblyjs/wast-printer": "1.12.1"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/helper-wasm-section": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-opt": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1",
+                "@webassemblyjs/wast-printer": "1.14.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-gen": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-            "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+            "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/ieee754": "1.11.6",
-                "@webassemblyjs/leb128": "1.11.6",
-                "@webassemblyjs/utf8": "1.11.6"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
             }
         },
         "node_modules/@webassemblyjs/wasm-opt": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-            "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+            "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-buffer": "1.12.1",
-                "@webassemblyjs/wasm-gen": "1.12.1",
-                "@webassemblyjs/wasm-parser": "1.12.1"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-buffer": "1.14.1",
+                "@webassemblyjs/wasm-gen": "1.14.1",
+                "@webassemblyjs/wasm-parser": "1.14.1"
             }
         },
         "node_modules/@webassemblyjs/wasm-parser": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-            "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+            "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
-                "@webassemblyjs/helper-api-error": "1.11.6",
-                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-                "@webassemblyjs/ieee754": "1.11.6",
-                "@webassemblyjs/leb128": "1.11.6",
-                "@webassemblyjs/utf8": "1.11.6"
+                "@webassemblyjs/ast": "1.14.1",
+                "@webassemblyjs/helper-api-error": "1.13.2",
+                "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+                "@webassemblyjs/ieee754": "1.13.2",
+                "@webassemblyjs/leb128": "1.13.2",
+                "@webassemblyjs/utf8": "1.13.2"
             }
         },
         "node_modules/@webassemblyjs/wast-printer": {
-            "version": "1.12.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-            "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+            "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/ast": "1.14.1",
                 "@xtuc/long": "4.2.2"
             }
         },
@@ -2712,6 +2789,7 @@
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "peer": true
         },
         "node_modules/@xtuc/long": {
@@ -2719,6 +2797,7 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "peer": true
         },
         "node_modules/abbrev": {
@@ -2730,24 +2809,15 @@
             "peer": true
         },
         "node_modules/acorn": {
-            "version": "8.12.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-            "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/acorn-import-attributes": {
-            "version": "1.9.5",
-            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-            "dev": true,
-            "peer": true,
-            "peerDependencies": {
-                "acorn": "^8"
             }
         },
         "node_modules/acorn-jsx": {
@@ -2985,9 +3055,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.23.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-            "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+            "version": "4.24.4",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+            "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
             "dev": true,
             "funding": [
                 {
@@ -3003,12 +3073,13 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "caniuse-lite": "^1.0.30001629",
-                "electron-to-chromium": "^1.4.796",
-                "node-releases": "^2.0.14",
-                "update-browserslist-db": "^1.0.16"
+                "caniuse-lite": "^1.0.30001688",
+                "electron-to-chromium": "^1.5.73",
+                "node-releases": "^2.0.19",
+                "update-browserslist-db": "^1.1.1"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3069,9 +3140,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001636",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001636.tgz",
-            "integrity": "sha512-bMg2vmr8XBsbL6Lr0UHXy/21m84FTxDLWn2FSqMd5PrlbMxwJlQnC2YWYxVgp66PZE+BBNF2jYQUBKCo1FDeZg==",
+            "version": "1.0.30001692",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
+            "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
             "dev": true,
             "funding": [
                 {
@@ -3087,6 +3158,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "CC-BY-4.0",
             "peer": true
         },
         "node_modules/canvas": {
@@ -3441,10 +3513,11 @@
             "peer": true
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -3781,10 +3854,11 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.810",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.810.tgz",
-            "integrity": "sha512-Kaxhu4T7SJGpRQx99tq216gCq2nMxJo+uuT6uzz9l8TVN2stL7M06MIIXAtr9jsrLs2Glflgf2vMQRepxawOdQ==",
+            "version": "1.5.83",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.83.tgz",
+            "integrity": "sha512-LcUDPqSt+V0QmI47XLzZrz5OqILSMGsPFkDYus22rIbgorSvBYEFqq854ltTmUdHkY92FSdAAvsh4jWEULMdfQ==",
             "dev": true,
+            "license": "ISC",
             "peer": true
         },
         "node_modules/element-plus": {
@@ -3828,10 +3902,11 @@
             }
         },
         "node_modules/enhanced-resolve": {
-            "version": "5.17.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz",
-            "integrity": "sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==",
+            "version": "5.18.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+            "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.4",
@@ -4219,10 +4294,11 @@
             }
         },
         "node_modules/escalade": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -6206,9 +6282,10 @@
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-            "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+            "license": "MIT",
             "dependencies": {
                 "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
@@ -6369,15 +6446,16 @@
             "peer": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "funding": [
                 {
                     "type": "github",
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -6421,10 +6499,11 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.14",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+            "version": "2.0.19",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
             "dev": true,
+            "license": "MIT",
             "peer": true
         },
         "node_modules/nopt": {
@@ -6761,9 +6840,10 @@
             }
         },
         "node_modules/picocolors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+            "license": "ISC"
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
@@ -6891,9 +6971,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.41",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.41.tgz",
-            "integrity": "sha512-TesUflQ0WKZqAvg52PWL6kHgLKP6xB6heTOdoYM0Wt2UHyxNa4K25EZZMgKns3BH1RLVbZCREPpLY0rhnNoHVQ==",
+            "version": "8.5.1",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+            "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -6908,10 +6988,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.7",
-                "picocolors": "^1.0.1",
-                "source-map-js": "^1.2.0"
+                "nanoid": "^3.3.8",
+                "picocolors": "^1.1.1",
+                "source-map-js": "^1.2.1"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -7789,9 +7870,10 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7990,6 +8072,7 @@
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=6"
@@ -8427,9 +8510,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-            "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+            "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
             "dev": true,
             "funding": [
                 {
@@ -8445,10 +8528,11 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "escalade": "^3.1.2",
-                "picocolors": "^1.0.1"
+                "escalade": "^3.2.0",
+                "picocolors": "^1.1.1"
             },
             "bin": {
                 "update-browserslist-db": "cli.js"
@@ -8612,12 +8696,13 @@
             }
         },
         "node_modules/vite-node/node_modules/rollup": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.20.0.tgz",
-            "integrity": "sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
+            "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.5"
+                "@types/estree": "1.0.6"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -8627,34 +8712,38 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.20.0",
-                "@rollup/rollup-android-arm64": "4.20.0",
-                "@rollup/rollup-darwin-arm64": "4.20.0",
-                "@rollup/rollup-darwin-x64": "4.20.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.20.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.20.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.20.0",
-                "@rollup/rollup-linux-arm64-musl": "4.20.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.20.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.20.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.20.0",
-                "@rollup/rollup-linux-x64-gnu": "4.20.0",
-                "@rollup/rollup-linux-x64-musl": "4.20.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.20.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.20.0",
-                "@rollup/rollup-win32-x64-msvc": "4.20.0",
+                "@rollup/rollup-android-arm-eabi": "4.30.1",
+                "@rollup/rollup-android-arm64": "4.30.1",
+                "@rollup/rollup-darwin-arm64": "4.30.1",
+                "@rollup/rollup-darwin-x64": "4.30.1",
+                "@rollup/rollup-freebsd-arm64": "4.30.1",
+                "@rollup/rollup-freebsd-x64": "4.30.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.30.1",
+                "@rollup/rollup-linux-arm64-musl": "4.30.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.30.1",
+                "@rollup/rollup-linux-x64-gnu": "4.30.1",
+                "@rollup/rollup-linux-x64-musl": "4.30.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.30.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.30.1",
+                "@rollup/rollup-win32-x64-msvc": "4.30.1",
                 "fsevents": "~2.3.2"
             }
         },
         "node_modules/vite-node/node_modules/vite": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.0.tgz",
-            "integrity": "sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==",
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+            "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
-                "postcss": "^8.4.40",
-                "rollup": "^4.13.0"
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -8952,12 +9041,13 @@
             }
         },
         "node_modules/vitest/node_modules/rollup": {
-            "version": "4.20.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.20.0.tgz",
-            "integrity": "sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==",
+            "version": "4.30.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.30.1.tgz",
+            "integrity": "sha512-mlJ4glW020fPuLi7DkM/lN97mYEZGWeqBnrljzN0gs7GLctqX3lNWxKQ7Gl712UAX+6fog/L3jh4gb7R6aVi3w==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.5"
+                "@types/estree": "1.0.6"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -8967,22 +9057,25 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.20.0",
-                "@rollup/rollup-android-arm64": "4.20.0",
-                "@rollup/rollup-darwin-arm64": "4.20.0",
-                "@rollup/rollup-darwin-x64": "4.20.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.20.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.20.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.20.0",
-                "@rollup/rollup-linux-arm64-musl": "4.20.0",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.20.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.20.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.20.0",
-                "@rollup/rollup-linux-x64-gnu": "4.20.0",
-                "@rollup/rollup-linux-x64-musl": "4.20.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.20.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.20.0",
-                "@rollup/rollup-win32-x64-msvc": "4.20.0",
+                "@rollup/rollup-android-arm-eabi": "4.30.1",
+                "@rollup/rollup-android-arm64": "4.30.1",
+                "@rollup/rollup-darwin-arm64": "4.30.1",
+                "@rollup/rollup-darwin-x64": "4.30.1",
+                "@rollup/rollup-freebsd-arm64": "4.30.1",
+                "@rollup/rollup-freebsd-x64": "4.30.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.30.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.30.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.30.1",
+                "@rollup/rollup-linux-arm64-musl": "4.30.1",
+                "@rollup/rollup-linux-loongarch64-gnu": "4.30.1",
+                "@rollup/rollup-linux-powerpc64le-gnu": "4.30.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.30.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.30.1",
+                "@rollup/rollup-linux-x64-gnu": "4.30.1",
+                "@rollup/rollup-linux-x64-musl": "4.30.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.30.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.30.1",
+                "@rollup/rollup-win32-x64-msvc": "4.30.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -9011,14 +9104,15 @@
             }
         },
         "node_modules/vitest/node_modules/vite": {
-            "version": "5.4.0",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.0.tgz",
-            "integrity": "sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==",
+            "version": "5.4.11",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
+            "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "esbuild": "^0.21.3",
-                "postcss": "^8.4.40",
-                "rollup": "^4.13.0"
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -9142,12 +9236,13 @@
             }
         },
         "node_modules/vue-i18n": {
-            "version": "9.13.1",
-            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.13.1.tgz",
-            "integrity": "sha512-mh0GIxx0wPtPlcB1q4k277y0iKgo25xmDPWioVVYanjPufDBpvu5ySTjP5wOrSvlYQ2m1xI+CFhGdauv/61uQg==",
+            "version": "9.14.2",
+            "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.2.tgz",
+            "integrity": "sha512-JK9Pm80OqssGJU2Y6F7DcM8RFHqVG4WkuCqOZTVsXkEzZME7ABejAUqUdA931zEBedc4thBgSUWxeQh4uocJAQ==",
+            "license": "MIT",
             "dependencies": {
-                "@intlify/core-base": "9.13.1",
-                "@intlify/shared": "9.13.1",
+                "@intlify/core-base": "9.14.2",
+                "@intlify/shared": "9.14.2",
                 "@vue/devtools-api": "^6.5.0"
             },
             "engines": {
@@ -9289,22 +9384,22 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.92.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.92.1.tgz",
-            "integrity": "sha512-JECQ7IwJb+7fgUFBlrJzbyu3GEuNBcdqr1LD7IbSzwkSmIevTm8PF+wej3Oxuz/JFBUZ6O1o43zsPkwm1C4TmA==",
+            "version": "5.97.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+            "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
             "dev": true,
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@types/eslint-scope": "^3.7.3",
-                "@types/estree": "^1.0.5",
-                "@webassemblyjs/ast": "^1.12.1",
-                "@webassemblyjs/wasm-edit": "^1.12.1",
-                "@webassemblyjs/wasm-parser": "^1.12.1",
-                "acorn": "^8.7.1",
-                "acorn-import-attributes": "^1.9.5",
-                "browserslist": "^4.21.10",
+                "@types/eslint-scope": "^3.7.7",
+                "@types/estree": "^1.0.6",
+                "@webassemblyjs/ast": "^1.14.1",
+                "@webassemblyjs/wasm-edit": "^1.14.1",
+                "@webassemblyjs/wasm-parser": "^1.14.1",
+                "acorn": "^8.14.0",
+                "browserslist": "^4.24.0",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.0",
+                "enhanced-resolve": "^5.17.1",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "test": "vitest"
     },
     "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.5.1",
+        "@fortawesome/fontawesome-free": "^6.7.2",
         "@mdi/font": "5.9.55",
         "@tiptap/core": "^2.0.3",
         "@tiptap/extension-character-count": "^2.0.3",
@@ -55,7 +55,7 @@
         "jsdoc": "^4.0.3",
         "jsdom": "^24.1.1",
         "prettier": "2.6.2",
-        "sass": "^1.77.6",
+        "sass": "^1.83.4",
         "typescript": "^4.5.4",
         "vite": "^2.9.18",
         "vite-plugin-vuetify": "^1.0.0-alpha.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@tiptap/extension-underline": "^2.0.3",
         "@tiptap/starter-kit": "^2.0.3",
         "@tiptap/vue-3": "^2.0.3",
-        "bootstrap": "^4.6.1",
+        "bootstrap": "^5.3.3",
         "canvas-to-svg": "^1.0.3",
         "codemirror": "^5.65.1",
         "codemirror-editor-vue3": "^2.1.7",

--- a/src/components/DialogBox/SaveImage.vue
+++ b/src/components/DialogBox/SaveImage.vue
@@ -34,7 +34,7 @@
                             v-if="toShow"
                             class="option inline btn-group btn-group-toggle"
                             style="border: none"
-                            data-toggle="buttons"
+                            data-bs-toggle="buttons"
                         >
                             <div
                                 id="radio-full"

--- a/src/components/Dropdown/DropDown.vue
+++ b/src/components/Dropdown/DropDown.vue
@@ -30,7 +30,7 @@
                 href="/users/sign_out"
                 class="dropdown-item"
                 rel="nofollow"
-                data-method="delete"
+                data-bs-method="delete"
             >
                 {{ $t('simulator.nav.sign_out') }}
             </a>

--- a/src/components/Navbar/Hamburger/Hamburger.vue
+++ b/src/components/Navbar/Hamburger/Hamburger.vue
@@ -3,8 +3,8 @@
     <button
         class="navbar-toggler collapsed"
         type="button"
-        data-toggle="collapse"
-        data-target="#bs-example-navbar-collapse-1"
+        data-bs-toggle="collapse"
+        data-bs-target="#bs-example-navbar-collapse-1"
         aria-controls="collapsedNavbar"
         aria-expanded="false"
         aria-label="Toggle navigation"

--- a/src/components/Navbar/Navbar.vue
+++ b/src/components/Navbar/Navbar.vue
@@ -11,7 +11,7 @@
 
             <span
                 id="projectName"
-                class="projectName noSelect defaultCursor font-weight-bold"
+                class="projectName noSelect defaultCursor fw-bold"
             >
                 {{ projectStore.getProjectName }}
             </span>

--- a/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink.vue
+++ b/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink.vue
@@ -3,7 +3,7 @@
         <a
             href="#"
             class=""
-            data-toggle="dropdown"
+            data-bs-toggle="dropdown"
             role="button"
             aria-haspopup="true"
             aria-expanded="false"

--- a/src/components/Navbar/QuickButton/QuickButton.vue
+++ b/src/components/Navbar/QuickButton/QuickButton.vue
@@ -75,7 +75,7 @@
             <input
                 id="customRange1"
                 type="range"
-                class="custom-range"
+                class="form-range"
                 min="0"
                 max="45"
                 step="1"

--- a/src/components/Navbar/QuickButton/QuickButtonMobile.vue
+++ b/src/components/Navbar/QuickButton/QuickButtonMobile.vue
@@ -86,7 +86,7 @@
           <input
               id="customRange1"
               type="range"
-              class="custom-range"
+              class="form-range"
               min="0"
               max="45"
               step="1"

--- a/src/components/Navbar/User/User.vue
+++ b/src/components/Navbar/User/User.vue
@@ -5,7 +5,7 @@
             <a
                 href="#"
                 class="cur-user acc-drop user-field"
-                data-toggle="dropdown"
+                data-bs-toggle="dropdown"
                 role="button"
                 aria-haspopup="true"
                 aria-expanded="false"

--- a/src/components/ReportIssue/ReportIssue.vue
+++ b/src/components/ReportIssue/ReportIssue.vue
@@ -15,12 +15,12 @@
                     <div class="container my-2">
                         <button
                             type="button"
-                            class="close"
-                            data-dismiss="modal"
+                            class="btn-close"
+                            data-bs-dismiss="modal"
                             aria-label="Close"
                             @click="closeReportModal"
                         >
-                            <span aria-hidden="true">&times;</span>
+                            
                         </button>
                         <div class="container text-center">
                             <h4>{{ $t('simulator.report_issue') }}</h4>
@@ -41,7 +41,7 @@
                                 )
                             }}</b></label
                         >
-                        <div class="form-group">
+                        <div class="mb-3">
                             <textarea
                                 v-if="issueText"
                                 id="issuetext"
@@ -66,7 +66,7 @@
                                 }}</span
                             >:</label
                         >
-                        <div class="form-group">
+                        <div class="mb-3">
                             <input
                                 v-if="issueEmail"
                                 id="emailtext"
@@ -81,7 +81,7 @@
                                 <button
                                     type="button"
                                     class="btn btn-primary close-btn"
-                                    data-dismiss="modal"
+                                    data-bs-dismiss="modal"
                                     aria-label="Close"
                                     @click="closeReportModal"
                                 >

--- a/src/components/ReportIssue/ReportIssueButton.vue
+++ b/src/components/ReportIssue/ReportIssueButton.vue
@@ -3,8 +3,8 @@
         <a
             type="button"
             class="btn btn-primary text-light"
-            data-toggle="modal"
-            data-target=".issue"
+            data-bs-toggle="modal"
+            data-bs-target=".issue"
             :style="{ bottom: simulatorMobileStore.showElementsPanel ? '250px' : '120px' }"
             @click="openReportingModal"
         >

--- a/src/styles/simulator.scss
+++ b/src/styles/simulator.scss
@@ -1,6 +1,7 @@
-$fa-font-path: '../../node_modules/@fortawesome/fontawesome-free/webfonts';
-@import '../../node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss';
-@import '../../node_modules/@fortawesome/fontawesome-free/scss/solid.scss';
+@use '@fortawesome/fontawesome-free/scss/fontawesome' with (
+    $fa-font-path: '../../node_modules/@fortawesome/fontawesome-free/webfonts'
+);
+@use '@fortawesome/fontawesome-free/scss/solid' as solid;
 
 .subcircuitdialog {
     display: none;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,18 @@ export default defineConfig(() => ({
             ),
         }),
     ],
+    css: {
+        preprocessorOptions: {
+            scss: {
+                includePaths: ['node_modules'],
+                sassOptions: {                      // For the color function deprecations. To remove after future bootstrap updates !
+                    quietDeps: true,                // i.e. when bootstrap has fixed its import methods as per sass requests.
+                    verbose: false  
+                }
+            }
+        }
+    },
+      
     resolve: {
         alias: {
             '#': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## This PR brings forth  
Bootstrap bump from 4.6.2 to 5.3.2 answering to [CVE-2024-6531](https://github.com/advisories/GHSA-vc8w-jr9v-vj7f)
### Vulnerability mitigation in 
- cross spawn : To prevent ReDoS [CVE-2024-21538](https://github.com/advisories/GHSA-3xgq-45jj-v275)
- nanoid : Fixes improper input validation [CVE-2024-55565](https://github.com/advisories/GHSA-mwcw-c2x4-8c55)
- micromatch : To prevent ReDoS [CVE-2024-4067](https://github.com/advisories/GHSA-952p-6rrq-rcjv)
- intlify/shared : To prevent prototype pollution vulnerability [CVE-2024-52810](https://github.com/advisories/GHSA-hjwq-mjwj-4x6c)
- intlify/core-base : In response to cross site scripting vulnerability   [CVE-2024-52809](https://github.com/advisories/GHSA-9r9m-ffp6-9x4v) 




