### PR TITLE
fixed extra popUp bug

### DIFF
--- a/src/simulator/src/data/project.ts
+++ b/src/simulator/src/data/project.ts
@@ -142,13 +142,11 @@ window.onbeforeunload = async function () {
  * Function to clear project
  */
 export async function clearProject() {
-    if (await confirmOption('Would you like to clear the project?')) {
         globalScope = undefined
         resetScopeList()
         // $('.circuits').remove()
         newCircuit('main')
         showMessage('Your project is as good as new!')
-    }
 }
 
 /**


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
I have not added any lines of code because there is no need for that . The problem was it was asking twice times to clearing the project from the user side but it was not needed so simply deleted the line where it was asking second time . Now it  is perfectly working and there will be now no more extra pop up appear after this 

### Screenshots of the changes (If any) -

Before Changes- 
[circuitverse.webm](https://github.com/user-attachments/assets/159b3a7a-2aa6-40a4-839f-9cf52f132d58)

After Changes- 
[Screencast from 2025-01-19 15-50-12.webm](https://github.com/user-attachments/assets/467bb03e-c642-4521-ad52-17cedaf4e0b5)
You can see here that it is not appearing any extra pop up dialog box .




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified project clearing process by removing confirmation step
	- Updated new project workflow with clearer unsaved changes warning

- **User Experience**
	- Streamlined project management interactions
	- Enhanced clarity around potential data loss when creating new projects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->