### PR TITLE
fix(driver location): update test bench driver location

### DIFF
--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -667,7 +667,7 @@ div.icon img {
     transition: background 0.5s ease-out;
     position: fixed;
     cursor: pointer;
-    left: 300px;
+    left: 380px;
     top: 90px;
 }
 
@@ -680,6 +680,7 @@ div.icon img {
     text-transform: uppercase;
     text-align: left;
     cursor: move;
+
 }
 
 /* Testbench UI Styling begin */
@@ -690,8 +691,8 @@ div.icon img {
     transition: background 0.5s ease-out;
     position: fixed;
     cursor: pointer;
-    left: 10px;
-    top: 470px;
+    left: 260px;
+    top: 90px;
 }
 
 .testbench-manual-panel .panel-header {
@@ -1890,7 +1891,7 @@ canvas {
 .messageBoxContent {
     height: auto;
     width: 760px;
-    justify-content: center;
+    justify-content: start;
     margin: auto;
     backdrop-filter: blur(5px);
     border-radius: 5px;
@@ -1916,11 +1917,15 @@ canvas {
     min-width: 50px;
     border: 1px solid #c5c5c5;
     padding: 5px 5px;
+    margin-inline-start: 9px;
 }
 
 .messageBtn:hover {
     background: #c5c5c5;
     color: black;
+}
+.messageBtn:focus {
+    border: 1px solid #c5c5c5;
 }
 
 .dialogHeader {


### PR DESCRIPTION
Fixes #420 

#### Describe the changes you have made in this PR -
1. Fixed the positioning issue of the driver by updating the `top` and `left` CSS properties of the timing diagram element. The driver is no longer overlapping any menu options.

2. Modified the `justify-content` property in the test bench creator dialog from `center` to `start`. This ensures that the starting elements remain accessible even when additional groups or tests are added to the container.

### Screenshots of the changes (If any) -
![image](https://github.com/user-attachments/assets/5fe16cdd-64c9-4b72-88f2-72a85a52635a)

![image](https://github.com/user-attachments/assets/43f55757-41f3-4c9f-b290-31d7e9beec6c)

![image](https://github.com/user-attachments/assets/6d8cc29b-3169-4b00-af4b-34b45e9fd9d8)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted positioning of timing diagram and testbench manual panels
	- Modified message box content alignment
	- Added margin and focus styling for message buttons

<!-- end of auto-generated comment: release notes by coderabbit.ai -->