### PR TITLE
fix: add netlify redirect rule to route root URL to /simulatorvue

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,12 @@
   command = "npm run build && mkdir -p ./dist && cp -r ../public/* ./dist/"
 
 [[redirects]]
+  from = "/"
+  to = "/simulatorvue"
+  status = 301
+  force = true
+  
+[[redirects]]
   from = "/simulatorvue/v0/*"
   to = "/simulatorvue/v0/index-cv.html"
   status = 200


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
- Added a redirect rule in the netlify.toml file to route the root URL (/) to /simulatorvue
- Tested locally to verify the redirection behavior

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a permanent redirect from the root URL ("/") to "/simulatorvue" to improve site navigation and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->