### PR TITLE
refactor:  z-index for visibility

### DIFF
--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -284,7 +284,6 @@ function isEmbed(): boolean {
     position: relative;
     overflow: hidden;
     padding-bottom: 2.5px;
-    z-index: 1;
 }
 
 #tabsBar.embed-tabbar {

--- a/v0/src/components/TabsBar/TabsBar.vue
+++ b/v0/src/components/TabsBar/TabsBar.vue
@@ -290,7 +290,6 @@ function isEmbed(): boolean {
     position: relative;
     overflow: hidden;
     padding-bottom: 2.5px;
-    z-index: 100;
 }
 
 #tabsBar.embed-tabbar {

--- a/v1/src/components/TabsBar/TabsBar.vue
+++ b/v1/src/components/TabsBar/TabsBar.vue
@@ -290,7 +290,6 @@ function isEmbed(): boolean {
     position: relative;
     overflow: hidden;
     padding-bottom: 2.5px;
-    z-index: 100;
 }
 
 #tabsBar.embed-tabbar {


### PR DESCRIPTION
### Describe the changes you have made in this PR -
- Removed Z-index property from `TabsBar.vue` for Dropdown list-items visibility.
- Files affected : `src\components\TabsBar\TabsBar.vue`, `v0\src\components\TabsBar\TabsBar.vue` and `v1\src\components\TabsBar\TabsBar.vue`.

### Screenshots of the changes (If any) -
#### Before Changes :
![image](https://github.com/user-attachments/assets/25e6488d-5a38-4a07-b17e-73a733738b9e)
#### After Changes
![image](https://github.com/user-attachments/assets/9275e1ca-0c6d-4ae0-ae54-d5bccb87cc62)




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the visual layering of the tabs component to ensure a more natural stacking order, enhancing how overlapping elements are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->