### PR TITLE
Fix: Change imports from partial v0/src and src to to complete v0/src

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,8 @@
         "width": 800,
         "height": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "devtools": true
       }
     ],
     "security": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
         "skipLibCheck": true,
         "baseUrl": "./",
         "paths": {
-            "#/*": ["./src/*"],
-            "@/*": ["./src/components/*"]
+            "#/*": ["./v0/src/*"],
+            "@/*": ["./v0/src/components/*"]
         },
         "allowJs": true,
         "declaration": true,
@@ -24,11 +24,11 @@
         "declarationMap": true
     },
     "include": [
-        "src/**/*.ts",
-        "src/**/*.d.ts",
-        "src/**/*.tsx",
-        "src/**/*.vue",
-        "src/**/*",
+        "v0/src/**/*.ts",
+        "v0/src/**/*.d.ts",
+        "v0/src/**/*.tsx",
+        "v0/src/**/*.vue",
+        "v0/src/**/*",
         "commitlint.config.js"
     ],
     "references": [{ "path": "./tsconfig.node.json" }]

--- a/v0/src/components/Navbar/Navbar.css
+++ b/v0/src/components/Navbar/Navbar.css
@@ -1,4 +1,4 @@
-@import url('/src/styles/color_theme.scss');
+@import url('/v0/src/styles/color_theme.scss');
 
 .navbar {
     background-color: var(--white);

--- a/v1/src/components/Navbar/Navbar.css
+++ b/v1/src/components/Navbar/Navbar.css
@@ -1,4 +1,4 @@
-@import url('/src/styles/color_theme.scss');
+@import url('/v1/src/styles/color_theme.scss');
 
 .navbar {
     background-color: var(--white);


### PR DESCRIPTION
### Earlier we had circuit logic imports from v0/src and front end imports from src which were causing ambiguitites in the desktop application and creating room for errors in the vue-simulator.

### *For example :*
*TypeScript thinks @/MyComponent is in ./src/components/, but at runtime, Vite tries to load it from ./v0/src/components/, causing:*
*- Module Not Found errors (Cannot find module)*
*- Inconsistent build/runtime behavior*
*- VSCode and ESLint auto-imports pointing to wrong locations*

### I have also enabled devtools in tauri to help enable better issue probing.

cc @niladrix719 @vedant-jain03 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - In-app developer tools are now enabled for enhanced debugging.

- **Chores**
  - Updated configuration settings and asset reference paths to align with a new directory organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->