### PR TITLE
UI Fix: Hide Unnecessary Dual Scrollbars in Verilog Code Window

### DIFF
--- a/v0/src/styles/css/main.stylesheet.css
+++ b/v0/src/styles/css/main.stylesheet.css
@@ -1729,12 +1729,12 @@ canvas {
 
 .code-window .CodeMirror {
     height: calc(100vh - 78px);
-    overflow: scroll;
+    overflow: hidden;
 }
 
 .code-window-embed .CodeMirror {
     height: 100%;
-    overflow: scroll;
+    overflow: hidden;
 }
 
 .code-window-embed {


### PR DESCRIPTION
#### Describe the changes you have made in this PR -
This PR fixes the issue of dual scrollbars appearing in the Verilog code window. The .CodeMirror container was previously allowing two scrollbars, one unnecessarily.

### Screenshots of the changes (If any) -
before
![image](https://github.com/user-attachments/assets/c9488303-7fe5-4947-a3e7-10b15cf7a2b8)
after
![image](https://github.com/user-attachments/assets/b162151e-f6c3-47c8-82e2-fc76bb18ce2a)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 