### PR TITLE
Fix Deprecated Husky install command

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "preview": "vite preview",
         "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
         "format": "prettier .  --write",
-        "postinstall": "husky install",
+        "postinstall": "husky .",
         "test": "vitest"
     },
     "dependencies": {


### PR DESCRIPTION
Fixes CircuitVerse/CircuitVerse#5574

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR -

This PR updates the Husky command in the package.json scripts section from the deprecated husky install to the current recommended syntax husky . which resolves the error being thrown during the prepare script execution.
Changes

## Changes
Updated the prepare script in package.json from husky install to husky .

## Testing Done

Verified that npm run prepare now executes without the "husky - install command is DEPRECATED" error
Confirmed that pre-commit hooks continue to function as expected

## Additional Notes

This change follows Husky's latest documentation and recommended usage pattern. [Husky\'s Official Changelog](https://github.com/typicode/husky/releases/tag/v9.0.1)
Since npm run prepare is used in various other scripts/functions, this fix resolves multiple related issues simultaneously

### Screenshots of the UI changes (If any) -
<!-- Do not add code diff here -->


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] If it is a core feature, I have added thorough tests.




Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the installation process to streamline the setup of commit hooks, aiming for a more consistent and reliable developer workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->