### PR TITLE
Fix: Dragging Panels Moving Outside Canvas & Ensure Proper Z-Index

### DIFF
--- a/src/simulator/src/drag.ts
+++ b/src/simulator/src/drag.ts
@@ -73,8 +73,8 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
     })
 
     $(DragEl).on('mousedown', () => {
-        $(`.draggable-panel:not(${DragEl})`).css('z-index', '99')
-        $(DragEl).css('z-index', '99')
+        $(`.draggable-panel:not(${DragEl})`).css('z-index', '101')
+        $(DragEl).css('z-index', '101')
     })
 
     let panelElements = document.querySelectorAll(

--- a/v0/src/simulator/src/drag.ts
+++ b/v0/src/simulator/src/drag.ts
@@ -73,8 +73,8 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
     })
 
     $(DragEl).on('mousedown', () => {
-        $(`.draggable-panel:not(${DragEl})`).css('z-index', '99')
-        $(DragEl).css('z-index', '99')
+        $(`.draggable-panel:not(${DragEl})`).css('z-index', '101')
+        $(DragEl).css('z-index', '101')
     })
 
     let panelElements = document.querySelectorAll(


### PR DESCRIPTION
Fixes #506 

#### Describe the changes you have made in this PR -
This PR addresses two issues related to draggable elements like Testbench and Timing Diagram in the simulator:

Elements Moving Outside the Canvas:
- Previously, these elements could be dragged beyond the workspace, making them inaccessible.
- Added constraints to keep them within the visible area.

Z-Index Issue:
- Dragged elements were appearing behind the navbar and properties panel.
- Updated drag.ts to ensure that the active draggable element always has the highest z-index (101).

This Ensure synchronous behaviour with circuitverse legacy simulator.
 
### Screenshots of the changes (If any) -
![image](https://github.com/user-attachments/assets/c0e1d03b-647d-48d5-98dd-b425d4972524)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the visual stacking of draggable panels by updating their z-index values during drag interactions, ensuring that the active panel is properly prioritized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->