### PR TITLE
fix: replace jQuery with Vue reactives in  v0/src/components/DialogBox/OpenOffline.vue

### DIFF
--- a/v0/src/components/DialogBox/OpenOffline.vue
+++ b/v0/src/components/DialogBox/OpenOffline.vue
@@ -27,6 +27,7 @@
                             type="radio"
                             name="projectId"
                             :value="projectId"
+                            v-model="selectedProjectId"
                         />
                         {{ projectName }}<span></span>
                         <i
@@ -92,6 +93,7 @@ import { onMounted, onUpdated, ref, toRaw } from '@vue/runtime-core'
 const SimulatorState = useState()
 const projectList = ref({})
 const targetVersion = ref('') 
+const selectedProjectId = ref('')
 let projectName = '' 
 onMounted(() => {
     SimulatorState.dialogBox.open_project_dialog = false
@@ -112,9 +114,8 @@ function deleteOfflineProject(id) {
 
 function openProjectOffline() {
     SimulatorState.dialogBox.open_project_dialog = false
-    let ele = $('input[name=projectId]:checked')
-    if (!ele.val()) return
-    const projectData = JSON.parse(localStorage.getItem(ele.val()))
+    if (!selectedProjectId.value) return
+    const projectData = JSON.parse(localStorage.getItem(selectedProjectId.value))
     const simulatorVersion = projectData.simulatorVersion
     projectName = projectData.name
     
@@ -130,7 +131,7 @@ function openProjectOffline() {
     } else {
         // For other cases, proceed normally
         load(projectData)
-        window.projectId = ele.val()
+        window.projectId = selectedProjectId.value
     }
 }
 


### PR DESCRIPTION


Fixes #433

#### Describe the changes you have made in this PR -

Removed jQuery DOM manipulation and migrated to Vue reactives in v0/src/components/DialogBox/OpenOffline.vue

### Screenshots of the changes (If any) -



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved project selection in the offline dialog by using Vue's reactive data binding instead of jQuery, resulting in a more seamless and responsive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->