### PR TITLE
Added Verilog Module for SR flip flop

### DIFF
--- a/src/simulator/src/sequential/SRflipFlop.js
+++ b/src/simulator/src/sequential/SRflipFlop.js
@@ -105,6 +105,41 @@ export default class SRflipFlop extends CircuitElement {
         this.state ? fillText(ctx, this.state.toString(16), xx, yy + 5) : fillText(ctx, '0', xx, yy + 5);
         ctx.fill()
     }
+    static moduleVerilog() {
+        return `
+module SRflipFlop(q,q_inv,s,r,clk,rst,pre,en);
+    output reg q,q_inv;
+    input wire s,r,clk,rst,pre,en;
+    
+    always @(posedge clk) begin
+        if (rst) begin
+            if (pre) begin
+                q     <= 1'b1;
+                q_inv <= 1'b0;
+            end else begin
+                q     <= 1'b0;
+                q_inv <= 1'b1;
+            end
+        end else if (en) begin
+            if (s && !r) begin
+                q    <= 1'b1;
+                q_inv <= 1'b0;
+            end else if (!s && r) begin
+                q     <= 1'b0;
+                q_inv <= 1'b1;
+            end else if (!s && !r) begin
+                q     <= q;     // hold state
+                q_inv <= q_inv;
+            end else begin
+                // Invalid condition: S = 1, R = 1 , the ideal output should be X(invalid state) but in this circuit model the state remains unchanged
+                q     <= q;
+                q_inv <= q_inv;
+            end
+        end
+    end
+endmodule
+    `
+    }
 }
 
 SRflipFlop.prototype.tooltipText = 'SR FlipFlop ToolTip : SR FlipFlop Selected.'

--- a/src/simulator/src/sequential/SRflipFlop.js
+++ b/src/simulator/src/sequential/SRflipFlop.js
@@ -122,7 +122,7 @@ module SRflipFlop(q,q_inv,s,r,clk,rst,pre,en);
             end
         end else if (en) begin
             if (s && !r) begin
-                q    <= 1'b1;
+                q     <= 1'b1;
                 q_inv <= 1'b0;
             end else if (!s && r) begin
                 q     <= 1'b0;

--- a/v1/src/simulator/src/sequential/SRflipFlop.js
+++ b/v1/src/simulator/src/sequential/SRflipFlop.js
@@ -121,6 +121,37 @@ export default class SRflipFlop extends CircuitElement {
         fillText(ctx, this.state.toString(16), xx, yy + 5)
         ctx.fill()
     }
+
+    static moduleVerilog() {
+        return `
+module SRflipFlop(q,q_inv,s,r,clk,rst,pre,en);
+    output reg q,q_inv;
+    input wire s,r,clk,rst,pre,en;
+    
+    always @(posedge clk or posedge rst) begin
+        if (rst) begin
+            q     <= 'b0;
+            q_inv <= 'b1;
+        end else if (en) begin
+            if (s && !r) begin
+                q    <= 1'b1;
+                q_inv <= 1'b0;
+            end else if (!s && r) begin
+                q     <= 1'b0;
+                q_inv <= 1'b1;
+            end else if (!s && !r) begin
+                q     <= q;     // hold state
+                q_inv <= q_inv;
+            end else begin
+                // Invalid condition: S = 1, R = 1
+                q     <= 1'bx;
+                q_inv <= 1'bx;
+            end
+        end
+    end
+endmodule
+    `
+    }
 }
 
 SRflipFlop.prototype.tooltipText = 'SR FlipFlop ToolTip : SR FlipFlop Selected.'

--- a/v1/src/simulator/src/sequential/SRflipFlop.js
+++ b/v1/src/simulator/src/sequential/SRflipFlop.js
@@ -128,10 +128,15 @@ module SRflipFlop(q,q_inv,s,r,clk,rst,pre,en);
     output reg q,q_inv;
     input wire s,r,clk,rst,pre,en;
     
-    always @(posedge clk or posedge rst) begin
+    always @(posedge clk) begin
         if (rst) begin
-            q     <= 'b0;
-            q_inv <= 'b1;
+            if (pre) begin
+                q     <= 1'b1;
+                q_inv <= 1'b0;
+            end else begin
+                q     <= 1'b0;
+                q_inv <= 1'b1;
+            end
         end else if (en) begin
             if (s && !r) begin
                 q    <= 1'b1;
@@ -143,9 +148,9 @@ module SRflipFlop(q,q_inv,s,r,clk,rst,pre,en);
                 q     <= q;     // hold state
                 q_inv <= q_inv;
             end else begin
-                // Invalid condition: S = 1, R = 1
-                q     <= 1'bx;
-                q_inv <= 1'bx;
+                // Invalid condition: S = 1, R = 1 , the ideal output should be X(invalid state) but in this circuit model the state remains unchanged
+                q     <= q;
+                q_inv <= q_inv;
             end
         end
     end

--- a/v1/src/simulator/src/sequential/SRflipFlop.js
+++ b/v1/src/simulator/src/sequential/SRflipFlop.js
@@ -121,42 +121,6 @@ export default class SRflipFlop extends CircuitElement {
         fillText(ctx, this.state.toString(16), xx, yy + 5)
         ctx.fill()
     }
-
-    static moduleVerilog() {
-        return `
-module SRflipFlop(q,q_inv,s,r,clk,rst,pre,en);
-    output reg q,q_inv;
-    input wire s,r,clk,rst,pre,en;
-    
-    always @(posedge clk) begin
-        if (rst) begin
-            if (pre) begin
-                q     <= 1'b1;
-                q_inv <= 1'b0;
-            end else begin
-                q     <= 1'b0;
-                q_inv <= 1'b1;
-            end
-        end else if (en) begin
-            if (s && !r) begin
-                q    <= 1'b1;
-                q_inv <= 1'b0;
-            end else if (!s && r) begin
-                q     <= 1'b0;
-                q_inv <= 1'b1;
-            end else if (!s && !r) begin
-                q     <= q;     // hold state
-                q_inv <= q_inv;
-            end else begin
-                // Invalid condition: S = 1, R = 1 , the ideal output should be X(invalid state) but in this circuit model the state remains unchanged
-                q     <= q;
-                q_inv <= q_inv;
-            end
-        end
-    end
-endmodule
-    `
-    }
 }
 
 SRflipFlop.prototype.tooltipText = 'SR FlipFlop ToolTip : SR FlipFlop Selected.'


### PR DESCRIPTION
Fixes #560

#### Describe the changes you have made in this PR -

1. Added the verilog module for SR flip flop
2. Async reset and preset were handled according to their circuit model

Note: Redundant assignments were done in case of S=1 ,R=1 to allow users to change it accordingly 



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to generate Verilog module code for the SR flip-flop, allowing users to easily obtain hardware descriptions directly from the simulator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->