### PR TITLE
Added the Verilog Module for D-latch

### DIFF
--- a/v0/src/simulator/src/sequential/Dlatch.js
+++ b/v0/src/simulator/src/sequential/Dlatch.js
@@ -110,6 +110,29 @@ export default class Dlatch extends CircuitElement {
         fillText(ctx, this.state.toString(16), xx, yy + 5)
         ctx.fill()
     }
+
+    static moduleVerilog() {
+return `
+    module Dlatch(
+        output reg q,q_inv,
+        input wire d,clk
+        );
+        always @(d or clk) 
+            begin
+                if (clk)
+                    begin
+                        q <= d;
+                        q_inv <= ~d; 
+                    end
+                else
+                    begin
+                        q <= q;
+                        q_inv <= q_inv;
+                    end
+            end
+    endmodule
+`
+    }
 }
 
 Dlatch.prototype.tooltipText = 'D Latch : Single input Flip flop or D FlipFlop'

--- a/v0/src/simulator/src/sequential/Dlatch.js
+++ b/v0/src/simulator/src/sequential/Dlatch.js
@@ -110,29 +110,6 @@ export default class Dlatch extends CircuitElement {
         fillText(ctx, this.state.toString(16), xx, yy + 5)
         ctx.fill()
     }
-
-    static moduleVerilog() {
-return `
-    module Dlatch(
-        output reg q,q_inv,
-        input wire d,clk
-        );
-        always @(d or clk) 
-            begin
-                if (clk)
-                    begin
-                        q <= d;
-                        q_inv <= ~d; 
-                    end
-                else
-                    begin
-                        q <= q;
-                        q_inv <= q_inv;
-                    end
-            end
-    endmodule
-`
-    }
 }
 
 Dlatch.prototype.tooltipText = 'D Latch : Single input Flip flop or D FlipFlop'

--- a/v1/src/simulator/src/sequential/Dlatch.js
+++ b/v1/src/simulator/src/sequential/Dlatch.js
@@ -110,6 +110,23 @@ export default class Dlatch extends CircuitElement {
         fillText(ctx, this.state.toString(16), xx, yy + 5)
         ctx.fill()
     }
+    static moduleVerilog() {
+return `
+    module Dlatch(q,q_inv,clk,d);
+        output reg q,q_inv;
+        input wire d,clk;
+        always @(d or clk) 
+            begin
+                if (clk)
+                    begin
+                        q <= d;
+                        q_inv <= ~d; 
+                    end
+                // prev state is preserved in case of else or clk = 0 
+            end
+    endmodule
+`
+    }
 }
 
 Dlatch.prototype.tooltipText = 'D Latch : Single input Flip flop or D FlipFlop'


### PR DESCRIPTION
Fixes #560 

#### Describe the changes you have made in this PR -

1. Added the verilog module for D-latch
2. clk is taken as en signal according to the circuit simulation model 



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 