### PR TITLE
added verilog module for testbench element

### DIFF
--- a/v1/src/simulator/src/testbench/testbenchInput.js
+++ b/v1/src/simulator/src/testbench/testbenchInput.js
@@ -317,6 +317,13 @@ export default class TB_Input extends CircuitElement {
 
         ctx.stroke()
     }
+    static moduleVerilog(){
+        return `
+module TB_Input(clk);
+        // this circuit element is used for testbench, avoid using this in Verilog Testing and simulation
+endmodule
+        `
+    }
 }
 
 TB_Input.prototype.tooltipText = 'Test Bench Input Selected'

--- a/v1/src/simulator/src/testbench/testbenchOutput.js
+++ b/v1/src/simulator/src/testbench/testbenchOutput.js
@@ -308,6 +308,13 @@ export default class TB_Output extends CircuitElement {
             }
         }
     }
+    static moduleVerilog(){
+        return `
+module TB_Output(clk);
+        // this circuit element is used for testbench, avoid using this in Verilog Testing and simulation
+endmodule
+        `
+    }
 }
 
 TB_Output.prototype.tooltipText = 'Test Bench Output Selected'


### PR DESCRIPTION
Fixes #560

#### Describe the changes you have made in this PR -

1. Added verilog module for testbench elements : TB_INPUT and TB_OUTPUT
2. SInce they are CircuitVerse constructs that are used for simulating the testbench , a warning was added to not include them in verilog simulation and testing.



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 