### PR TITLE
fix: prevent wires from breaking or adding extra nodes unexpectedly

### DIFF
--- a/src/simulator/src/wire.ts
+++ b/src/simulator/src/wire.ts
@@ -101,6 +101,10 @@ export default class Wire {
 
     checkWithin(x: number, y: number): boolean {
         const threshold = 2;
+        return this.checkCoordAndBetween(x, y, threshold);
+    }
+
+    private checkCoordAndBetween(x: number, y: number, threshold: number): boolean {
         if (this.type === 'horizontal') {
             return this.checkCoordinate(y, this.node1.absY(), threshold) &&
                 this.isBetween(x, this.node1.absX(), this.node2.absX());
@@ -212,18 +216,32 @@ export default class Wire {
         return false;
     }
 
+    private createAlignmentPoint(
+        current: number,
+        expected: number,
+        x: number,
+        y: number,
+        scopeRoot: CircuitElement,
+        referenceNode: Node
+    ): { current: number, expected: number, createNode: () => Node, referenceNode: Node } {
+        return {
+            current,
+            expected,
+            createNode: () => new Node(x, y, 2, scopeRoot),
+            referenceNode
+        };
+    }
+
     private alignNodesAlongYAxis(): boolean {
-        return this.checkAndCreateNode(
-            { current: this.node1.absY(), expected: this.y1, createNode: () => new Node(this.node1.absX(), this.y1, 2, this.scope.root), referenceNode: this.node1 },
-            { current: this.node2.absY(), expected: this.y2, createNode: () => new Node(this.node2.absX(), this.y2, 2, this.scope.root), referenceNode: this.node2 }
-        );
+        const p1 = this.createAlignmentPoint(this.node1.absY(), this.y1, this.node1.absX(), this.y1, this.scope.root, this.node1);
+        const p2 = this.createAlignmentPoint(this.node2.absY(), this.y2, this.node2.absX(), this.y2, this.scope.root, this.node2);
+        return this.checkAndCreateNode(p1, p2);
     }
 
     private alignNodesAlongXAxis(): boolean {
-        return this.checkAndCreateNode(
-            { current: this.node1.absX(), expected: this.x1, createNode: () => new Node(this.x1, this.node1.absY(), 2, this.scope.root), referenceNode: this.node1 },
-            { current: this.node2.absX(), expected: this.x2, createNode: () => new Node(this.x2, this.node2.absY(), 2, this.scope.root), referenceNode: this.node2 }
-        );
+        const p1 = this.createAlignmentPoint(this.node1.absX(), this.x1, this.x1, this.node1.absY(), this.scope.root, this.node1);
+        const p2 = this.createAlignmentPoint(this.node2.absX(), this.x2, this.x2, this.node2.absY(), this.scope.root, this.node2);
+        return this.checkAndCreateNode(p1, p2);
     }
 
     private checkNode(


### PR DESCRIPTION
Fixes #610

#### Describe the changes you have made in this PR -

This pull request fixes a bug in the Vue simulator where wires connecting nodes would sometimes break or add extra nodes on their own when users clicked or dragged near them. The update improves the wire handling logic to keep connections stable and prevent unwanted changes, making the circuit layout cleaner and easier to use.

### Screenshots of the changes (If any) -

After --

https://github.com/user-attachments/assets/35b8734c-487c-4fbe-ba0f-94f2e5e16f6f


Before --

https://github.com/user-attachments/assets/4a1d4d70-42c1-44e0-96d7-37409a861fa0


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved wire hit detection by allowing a small margin of error for coordinate matching, making it easier to select or interact with wires.
	- Prevented unnecessary node creation and redundant wire connections for smoother simulation performance.
	- Deferred the removal of disconnected wires to avoid abrupt changes during interactions.

- **Improvements**
	- Enhanced reliability and accuracy in wire orientation and node alignment within the simulator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->