### PR TITLE
Made the verilog module consistent with the Circuit simulation logic

### DIFF
--- a/src/simulator/src/sequential/DflipFlop.js
+++ b/src/simulator/src/sequential/DflipFlop.js
@@ -135,13 +135,18 @@ export default class DflipFlop extends CircuitElement {
 module DflipFlop(q, q_inv, clk, d, a_rst, pre, en);
     parameter WIDTH = 1;
     output reg [WIDTH-1:0] q, q_inv;
-    input clk, a_rst, pre, en;
-    input [WIDTH-1:0] d;
+    input clk, a_rst, en;
+    input [WIDTH-1:0] d, pre;
 
     always @ (posedge clk or posedge a_rst)
     if (a_rst) begin
-        q <= 'b0;
-        q_inv <= 'b1;
+        if (^pre === 1'bx) begin
+            q <= {WIDTH{1'b0}};
+            q_inv <= {WIDTH{1'b1}};
+        end else begin
+            q <= pre;
+            q_inv <= ~pre;
+        end
     end else if (en == 0) ;
     else begin
         q <= d;


### PR DESCRIPTION
Fixes #561 

#### Describe the changes you have made in this PR -
1. Added the logic for pre parameter in the verilog module
2. According to simulation logic pre is not a control signal but a register which sets the q or output



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 