### PR TITLE
Revamping the verilog code editor - 01

### DIFF
--- a/src/simulator/src/Verilog2CV.js
+++ b/src/simulator/src/Verilog2CV.js
@@ -26,6 +26,7 @@ import 'codemirror/theme/midnight.css'
 import 'codemirror/addon/hint/show-hint.css'
 import 'codemirror/mode/verilog/verilog.js'
 import 'codemirror/addon/edit/closebrackets.js'
+import 'codemirror/addon/edit/matchbrackets.js'
 import 'codemirror/addon/hint/anyword-hint.js'
 import 'codemirror/addon/hint/show-hint.js'
 import 'codemirror/addon/display/autorefresh.js'
@@ -286,6 +287,7 @@ export function setupCodeMirrorEnvironment() {
         styleActiveLine: true,
         lineNumbers: true,
         autoCloseBrackets: true,
+        matchBrackets: true,
         smartIndent: true,
         indentWithTabs: true,
         extraKeys: { 'Ctrl-Space': 'autocomplete' },

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -1731,6 +1731,17 @@ canvas {
     overflow: scroll;
 }
 
+.CodeMirror-sizer {
+    margin-left: 55px !important;
+    padding-left: 15px !important;
+    line-height: 1.35 !important;
+}
+
+.CodeMirror pre {
+  font-family: 'JetBrains Mono', monospace !important;
+  font-size: 18px !important;
+}
+
 .code-window-embed {
     position: absolute;
     top: 28px;


### PR DESCRIPTION
Fixes #562 

#### Describe the changes you have made in this PR -
1. Added new font style - JetBrains Mono
2. Added automatic bracket matching
3. Added space and padding between line numbers and page end , and line number and code text
4. Increased the font size
5. Increased the line height

### Screenshots of the changes (If any) -

<img width="1851" height="911" alt="Screenshot from 2025-07-17 19-52-42" src="https://github.com/user-attachments/assets/371d2420-b624-4257-8385-ade1c3b7cb33" />

<img width="1851" height="911" alt="Screenshot from 2025-07-17 19-52-37" src="https://github.com/user-attachments/assets/d7a71daf-d096-49b5-bf3f-a8262c12613d" />



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 