### PR TITLE
docs: add destop application development instructions using tauri

### DIFF
--- a/src-tauri/README.md
+++ b/src-tauri/README.md
@@ -1,0 +1,19 @@
+## Desktop Application Development (Tauri)
+
+
+You can also run CircuitVerse as a destop application using [tauri](https://tauri.app/)
+
+## Prerequisites
+
+make sure to the following are installed on your system
+
+[node.js](https://node.js.org) (>= 16)
+[npm] (https://www.npmjs.com/)
+[Rust & Cargo] (https://rustup.rs/)
+(required by tauri)
+Tauri CLI (install with : `cargo install tauri-cli`)
+
+### Run the app in development Mode 
+```bash
+
+npm run tauri dev


### PR DESCRIPTION
Fixes #

#### Describe the changes you have made in this PR -
This PR adds documentation for running and building the desktop application using Tauri
### Screenshots of the changes (If any) -
<img width="1679" height="668" alt="Screenshot 2025-09-03 124727" src="https://github.com/user-attachments/assets/9a331753-0e18-4e63-947c-e6aa71c31789" />

Here are all the changes

Added Commands to run in development mode (`npm run tauri dev`)

Added commands to build for production(`npm run tauri build`)



Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 