### PR TITLE
Expected to return JSON but returning string

### DIFF
--- a/v0/src/simulator/src/data/save.js
+++ b/v0/src/simulator/src/data/save.js
@@ -139,8 +139,6 @@ export async function generateSaveData(name, setName = true) {
         saveScope(id)
     }
 
-    // convert to text
-    data = JSON.stringify(data)
     return data
 }
 


### PR DESCRIPTION
### Problem:
The `localStorage ("recover") ` is double stringified causing the recover circuit to always show untitled

### Fixed:
The function signature mentioned returning JSON but string was sent. Removed the unnessary conversion before return

### Further note:
Same issue in v1, @maintainers please change there also