### PR TITLE
types(global): add Window interface declarations for simulator globals

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,24 @@
+/* Type-only global augmentations for window properties used across the app.
+   This file adds declarations only — no runtime changes. */
+export {}
+
+declare global {
+  interface Window {
+    $?: any
+    jQuery?: any
+    isUserLoggedIn?: boolean
+    logixProjectId?: number | string | undefined
+    restrictedElements?: any[]
+    globalScope?: any
+    lightMode?: boolean
+    projectId?: number | string | undefined
+    id?: number | string | undefined
+    loading?: boolean
+    embed?: boolean
+    width?: number | undefined
+    height?: number | undefined
+    DPR?: number
+}
+}
+
+


### PR DESCRIPTION
Fixes #661

#### Describe the changes you have made in this PR -
Added a new type declaration file (`src/types/global.d.ts`) defining common `window` properties used across the simulator (e.g., `globalScope`, `lightMode`, `projectId`, `embed`, etc.).  
This improves TypeScript type safety and removes the need for repetitive `@ts-ignore` comments.

### Screenshots of the changes (If any) -
<img width="1582" height="948" alt="Screenshot 2025-11-09 at 6 43 37 AM" src="https://github.com/user-attachments/assets/1b0c1911-7448-4c49-9e25-5652858d39a4" />


---

Note: Please check **Allow edits from maintainers.** ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced TypeScript type definitions for improved developer experience and type safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->