### PR TITLE
feat(simulator): add confirmation dialog before clearing canvas

### DIFF
--- a/src/components/helpers/createNewProject/TextEditor.vue
+++ b/src/components/helpers/createNewProject/TextEditor.vue
@@ -252,9 +252,16 @@ export default {
                 undo: () => vm.undo().run(),
                 redo: () => vm.redo().run(),
                 clear: () => {
-                    vm.clearNodes().run()
-                    vm.unsetAllMarks().run()
-                },
+    const confirmed = window.confirm(
+        'Are you sure you want to clear the canvas? This action cannot be undone.'
+    )
+
+    if (!confirmed) return
+
+    vm.clearNodes().run()
+    vm.unsetAllMarks().run()
+},
+
             }
 
             actionTriggers[slug]()


### PR DESCRIPTION
Fixes #701 

#### Describe the changes you have made in this PR - Added a confirmation dialog before clearing the Vue simulator canvas to prevent accidental data loss. The canvas is cleared only if the user confirms the action.

### Screenshots of the changes (If any) - 
<img width="1918" height="972" alt="image" src="https://github.com/user-attachments/assets/6c667c19-eed0-4514-b055-ddfed8d58804" />

Summary:
Clicking Clear Project previously removed all components and wires immediately, which could lead to accidental loss of work. This PR adds a safety confirmation dialog.

Problem:
Users could accidentally lose work by clicking Clear Project without warning.

Solution:
->Shows a confirmation dialog before clearing.
->Canvas is cleared only if the user clicks OK.

Implementation details:
->Wrapped the existing clear logic with a confirmation check
->Uses native window.confirm for minimal risk
->No other simulator logic was modified

File changed:
src/components/helpers/createNewProject/TextEditor.vue

Related issue
Closes #701


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when clearing the canvas to prevent accidental data loss.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->