### PR TITLE
fix(docs): correct JSDoc typos and grammar in simulator files

### DIFF
--- a/src/simulator/src/hotkey_binder/view/panel.ui.js
+++ b/src/simulator/src/hotkey_binder/view/panel.ui.js
@@ -1,8 +1,8 @@
 import { setUserKeys } from '../model/actions'
 
 /**
- * fn to update the htokey panel UI with the currently set configuration
- * @param {string} mode user prefered if present, or default keys configuration
+ * fn to update the hotkey panel UI with the currently set configuration
+ * @param {string} mode user preferred if present, or default keys configuration
  */
 export const updateHTML = (mode) => {
     let x = 0

--- a/src/simulator/src/modules/Arrow.js
+++ b/src/simulator/src/modules/Arrow.js
@@ -7,7 +7,7 @@ import { correctWidth, lineTo, moveTo } from '../canvasApi'
  * @extends CircuitElement
  * @param {number} x - x coordinate of element.
  * @param {number} y - y coordinate of element.
- * @param {Scope=} scope - Cirucit on which element is drawn
+ * @param {Scope=} scope - Circuit on which element is drawn
  * @param {string=} dir - direction of element
  * @category modules
  */

--- a/src/simulator/src/sequential/EEPROM.js
+++ b/src/simulator/src/sequential/EEPROM.js
@@ -12,12 +12,12 @@ import RAM from './RAM'
  * This is basically a RAM component that persists its contents.
  *
  * We consider EEPROMs more 'expensive' than RAMs, so we arbitrarily limit
- * the addressWith to a maximum of 10 bits (1024 addresses) with a default of 8-bit (256).
+ * the addressWidth to a maximum of 10 bits (1024 addresses) with a default of 8-bit (256).
  *
  * In the EEPROM all addresses are initialized to zero.
  * This way we serialize unused values as "0" instead of "null".
  *
- * These two techniques help keep reduce the size of saved projects.
+ * These two techniques helps reduce the size of saved projects.
  * @category sequential
  */
 export default class EEPROM extends RAM {


### PR DESCRIPTION
Fixes #710 

#### Describe the changes you have made in this PR -
This PR fixes minor spelling, grammar, and wording issues in JSDoc comments across simulator source files. These changes are documentation only and do not affect any application logic.

## Changes Made
- Corrected `htokey` → `hotkey` in JSDoc comments
- Fixed parameter description typo `prefered` → `preferred`
- Corrected `Cirucit` → `Circuit` in JSDoc parameter documentation
- Renamed `addressWith` → `addressWidth` for clarity
- Improved grammar in comments (e.g., “help keep reduce the size” → “helps reduce the size”)

## Affected Files
- `src/simulator/src/hotkey_binder/view/panel.ui.js`
- `src/simulator/src/modules/Arrow.js`
- `src/simulator/src/sequential/EEPROM.js`

### Screenshots of the changes (If any) -
Not applicable (documentation-only changes).


Note: Please check **Allow edits from maintainers.** if you would like us to assist in the PR. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Corrected typos and grammar issues in code comments and documentation strings across simulator components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->