### PR TITLE
ci: re-enable Windows builds in Tauri release workflow

### DIFF
--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -21,7 +21,8 @@ jobs:
             args: '--target x86_64-apple-darwin'  # Intel Mac
           - platform: 'ubuntu-22.04'
             args: ''
-          
+          - platform: 'windows-latest'
+            args: ''
 
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Re-adds Windows platform to the build matrix after it was previously disabled in commit 9f8eaf1. This restores multi-platform build support for Windows alongside macOS (Intel/Apple Silicon) and Linux.

The workflow will now generate Windows installers:
- .msi (Windows Installer Package)
- .exe (NSIS-based installer)

All necessary Windows configuration is already in place:
- icon.ico exists in src-tauri/icons/
- Artifact upload paths configured for both msi and nsis
- Cross-platform build commands using npx cross-env


Also the simulator works fine in local server .
<img width="1919" height="1138" alt="image" src="https://github.com/user-attachments/assets/0fc03391-2535-40d2-a647-3e9471dc22ed" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system infrastructure to support Windows platform builds in the automated release pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->