### PR TITLE
fix: prevent components from overlapping when placed from sidebar

### DIFF
--- a/src/components/Panels/ElementsPanel/ElementsPanel.ts
+++ b/src/components/Panels/ElementsPanel/ElementsPanel.ts
@@ -5,8 +5,12 @@ import { uxvar } from "#/simulator/src/ux"
 export function createElement(elementName: string) {
   if (simulationArea.lastSelected?.newElement)
       simulationArea.lastSelected.delete()
+  // Set drop position before creating element so components don't overlap
+  simulationArea.mouseX = uxvar.smartDropXX
+  simulationArea.mouseY = uxvar.smartDropYY
   var obj = new modules[elementName]()
   simulationArea.lastSelected = obj
+  // Increment position for next element
   uxvar.smartDropXX += 70
   if (uxvar.smartDropXX / globalScope.scale > width) {
       uxvar.smartDropXX = 50

--- a/v0/src/components/Panels/ElementsPanel/ElementsPanel.ts
+++ b/v0/src/components/Panels/ElementsPanel/ElementsPanel.ts
@@ -5,8 +5,12 @@ import { uxvar } from "#/simulator/src/ux"
 export function createElement(elementName: string) {
   if (simulationArea.lastSelected?.newElement)
       simulationArea.lastSelected.delete()
+  // Set drop position before creating element so components don't overlap
+  simulationArea.mouseX = uxvar.smartDropXX
+  simulationArea.mouseY = uxvar.smartDropYY
   var obj = new modules[elementName]()
   simulationArea.lastSelected = obj
+  // Increment position for next element
   uxvar.smartDropXX += 70
   if (uxvar.smartDropXX / globalScope.scale > width) {
       uxvar.smartDropXX = 50

--- a/v1/src/components/Panels/ElementsPanel/ElementsPanel.ts
+++ b/v1/src/components/Panels/ElementsPanel/ElementsPanel.ts
@@ -5,8 +5,12 @@ import { uxvar } from "#/simulator/src/ux"
 export function createElement(elementName: string) {
   if (simulationArea.lastSelected?.newElement)
       simulationArea.lastSelected.delete()
+  // Set drop position before creating element so components don't overlap
+  simulationArea.mouseX = uxvar.smartDropXX
+  simulationArea.mouseY = uxvar.smartDropYY
   var obj = new modules[elementName]()
   simulationArea.lastSelected = obj
+  // Increment position for next element
   uxvar.smartDropXX += 70
   if (uxvar.smartDropXX / globalScope.scale > width) {
       uxvar.smartDropXX = 50


### PR DESCRIPTION
## Description

This PR fixes an issue where new components placed from the sidebar would stack on top of each other at the same position, making it difficult to distinguish individual components.

## Problem

When clicking on components in the left sidebar to add them to the canvas, all components were being placed at the same position because `simulationArea.mouseX/Y` was not being set to the smart drop offset before creating the element.

## Solution

Set `simulationArea.mouseX` and `simulationArea.mouseY` to the `uxvar.smartDropXX/YY` offset values **before** instantiating the module. This ensures each new component is placed at a unique offset position.

## Changes

Modified [createElement](cci:1://file:///Users/hmshuu/Desktop/Circuitverse%20vue%20/cv-frontend-vue/v1/src/components/Panels/ElementsPanel/ElementsPanel.ts:4:0-18:1) function in:
- [src/components/Panels/ElementsPanel/ElementsPanel.ts](cci:7://file:///Users/hmshuu/Desktop/Circuitverse%20vue%20/cv-frontend-vue/src/components/Panels/ElementsPanel/ElementsPanel.ts:0:0-0:0)
- [v0/src/components/Panels/ElementsPanel/ElementsPanel.ts](cci:7://file:///Users/hmshuu/Desktop/Circuitverse%20vue%20/cv-frontend-vue/v0/src/components/Panels/ElementsPanel/ElementsPanel.ts:0:0-0:0)
- [v1/src/components/Panels/ElementsPanel/ElementsPanel.ts](cci:7://file:///Users/hmshuu/Desktop/Circuitverse%20vue%20/cv-frontend-vue/v1/src/components/Panels/ElementsPanel/ElementsPanel.ts:0:0-0:0)

```typescript
// Set drop position before creating element so components don't overlap
simulationArea.mouseX = uxvar.smartDropXX
simulationArea.mouseY = uxvar.smartDropYY
```

fixes #736 

