### PR TITLE
feat: add GitHub Releases workflow for version tracking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           generate_release_notes: true
           draft: false


### PR DESCRIPTION
- Add release.yml workflow that triggers on version tags (v*.*.*)
- Uses softprops/action-gh-release for automated release creation
- Generates release notes automatically from commits
- Enables Community Dashboard to track Vue Simulator versions

Fixes #753

#### Describe the changes you have made in this PR -

Added a new GitHub Actions workflow ([.github/workflows/release.yml](cci:7://file:///Users/hmshuu/Desktop/Circuitverse%20vue%20/cv-frontend-vue/.github/workflows/release.yml:0:0-0:0)) that automatically creates GitHub Releases when version tags are pushed. This enables the Community Dashboard to fetch and display Vue Simulator version history via the GitHub Releases API.

**Workflow Details:**
- Triggers on tag pushes matching `v*.*.*` (e.g., `v1.0.0`, `v2.1.3`)
- Uses `softprops/action-gh-release@v2` action
- Auto-generates release notes from commits since the last tag
- Creates published (non-draft) releases

### Screenshots of the UI changes (If any) -

N/A - This is a CI/CD workflow change with no UI modifications.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem solved**: The Community Dashboard cannot track Vue Simulator versions because the GitHub Releases API returns an empty array for this repository.

**Alternative approaches considered**:
1. Manual release creation - rejected due to maintenance overhead
2. Trigger on every push to main - rejected as it would create too many releases
3. Tag-based trigger (chosen) - clean, explicit versioning with semantic versioning support

**Why this implementation**: 
- The `softprops/action-gh-release` action is well-maintained and widely used
- Auto-generated release notes reduce maintenance burden while providing useful changelogs
- Tag-based triggers give maintainers explicit control over when releases are published

**Key components**:
- `on.push.tags: 'v*.*.*'` - Triggers workflow only on semantic version tags
- `fetch-depth: 0` - Fetches full git history for accurate release note generation
- `generate_release_notes: true` - Automatically compiles commits into release notes

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated release publishing triggered by version tags (vX.Y.Z).
  * Releases are published automatically (not drafts or prereleases).
  * Release notes are generated automatically for each published release.
  * Publishing uses the repository's authentication token for secure uploads.
  * Reduces manual steps for creating and publishing versioned releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->