### PR TITLE
refactor: remove jQuery from drag.ts

### DIFF
--- a/src/simulator/src/drag.ts
+++ b/src/simulator/src/drag.ts
@@ -73,18 +73,16 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
     })
 
     // Handle z-index on mousedown using native DOM
-    const dragElement = document.querySelector(DragEl as unknown as string) as HTMLElement | null
-    if (dragElement) {
-        dragElement.addEventListener('mousedown', () => {
-            // Reset z-index for other panels
-            const otherPanels = document.querySelectorAll(`.draggable-panel:not(${DragEl})`)
-            otherPanels.forEach((panel) => {
-                (panel as HTMLElement).style.zIndex = '99'
-            })
-            // Set z-index for current panel
-            dragElement.style.zIndex = '99'
+    DragEl.addEventListener('mousedown', () => {
+        // Reset z-index for other panels (lower priority)
+        document.querySelectorAll<HTMLElement>('.draggable-panel').forEach((panel) => {
+            if (panel !== DragEl) {
+                panel.style.zIndex = '98'
+            }
         })
-    }
+        // Set higher z-index for current panel to bring it to front
+        DragEl.style.zIndex = '99'
+    })
 
     let panelElements = document.querySelectorAll(
         '.elementPanel, .layoutElementPanel, #moduleProperty, #layoutDialog, #verilogEditorPanel, .timing-diagram-panel, .testbench-manual-panel, .quick-btn'

--- a/src/simulator/src/drag.ts
+++ b/src/simulator/src/drag.ts
@@ -72,10 +72,19 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
         ],
     })
 
-    $(DragEl).on('mousedown', () => {
-        $(`.draggable-panel:not(${DragEl})`).css('z-index', '99')
-        $(DragEl).css('z-index', '99')
-    })
+    // Handle z-index on mousedown using native DOM
+    const dragElement = document.querySelector(DragEl as unknown as string) as HTMLElement | null
+    if (dragElement) {
+        dragElement.addEventListener('mousedown', () => {
+            // Reset z-index for other panels
+            const otherPanels = document.querySelectorAll(`.draggable-panel:not(${DragEl})`)
+            otherPanels.forEach((panel) => {
+                (panel as HTMLElement).style.zIndex = '99'
+            })
+            // Set z-index for current panel
+            dragElement.style.zIndex = '99'
+        })
+    }
 
     let panelElements = document.querySelectorAll(
         '.elementPanel, .layoutElementPanel, #moduleProperty, #layoutDialog, #verilogEditorPanel, .timing-diagram-panel, .testbench-manual-panel, .quick-btn'

--- a/v1/src/simulator/src/drag.ts
+++ b/v1/src/simulator/src/drag.ts
@@ -72,9 +72,16 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
         ],
     })
 
-    $(DragEl).on('mousedown', () => {
-        $(`.draggable-panel:not(${DragEl})`).css('z-index', '99')
-        $(DragEl).css('z-index', '99')
+    // Handle z-index on mousedown using native DOM
+    DragEl.addEventListener('mousedown', () => {
+        // Reset z-index for other panels (lower priority)
+        document.querySelectorAll<HTMLElement>('.draggable-panel').forEach((panel) => {
+            if (panel !== DragEl) {
+                panel.style.zIndex = '98'
+            }
+        })
+        // Set higher z-index for current panel to bring it to front
+        DragEl.style.zIndex = '99'
     })
 
     let panelElements = document.querySelectorAll(


### PR DESCRIPTION
Fixes #433

#### Describe the changes you have made in this PR -
Removed jQuery from `src/simulator/src/drag.ts` and replaced with native DOM APIs.

**Changes:**
- Replaced `$(DragEl).on('mousedown', fn)` → `element.addEventListener('mousedown', fn)`
- Replaced `$().css('z-index', '99')` → `element.style.zIndex = '99'`

---

## Code Understanding and AI Usage
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized drag interaction internals; panel stacking adjusted so non-selected panels sit slightly lower while the active panel remains on top. Visual drag behavior is preserved and there are no public API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->