### PR TITLE
fix(simulator): trigger simulation on wire creation 

### DIFF
--- a/src/simulator/src/wire.ts
+++ b/src/simulator/src/wire.ts
@@ -34,6 +34,7 @@ export default class Wire {
         this.updateData();
         this.scope.wires.push(this);
         forceResetNodesSet(true);
+        updateSimulationSet(true);
     }
 
     updateData(): void {


### PR DESCRIPTION
Fixes #734 

Simulation is not being triggered when a wire was created.
As a result, outputs could remain in an undefined (X) state until another event (such as toggling an input) occured which forced recomputation.

This PR ensures that the simulation engine is explicitly triggered whenever a wire is created, making signal propagation deterministic across platforms.

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself

Describe in your own words:
- What problem does your code solve?
Simulation was not triggered on wire creation, causing outputs to stay in an undefined (X) state until another interaction or manual intervention.
_Root Cause -_
The simulation engine runs only when `updateSimulationSet` is set to true.
While wire deletion already triggered this flag, wire creation did not, thus leading to a race condition or signal propagation issue on some platforms (as notified on macOS/Tauri).
_Solution -_
Trigger simulation recomputation immediately when a wire is created by calling:
`forceResetNodesSet(true)`
`updateSimulationSet(true)`

- Why did you choose this specific implementation?
Following the existing engine design, this approach restores symmetry between wire creation and deletion, and removes platform-specific timing dependence without introducing any new logic.

- What are the key functions/components and what do they do?
The Wire constructor now explicitly triggers simulation recomputation, ensuring consistent behavior across all environments.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the simulation state was not properly updating when creating new wires.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->