### PR TITLE
fix(ALU): correct borrow flag for subtraction and handle CTR=3 stale …

### DIFF
--- a/src/simulator/src/modules/ALU.js
+++ b/src/simulator/src/modules/ALU.js
@@ -145,7 +145,12 @@ export default class ALU extends CircuitElement {
             simulationArea.simulationQueue.add(this.output)
             this.message = 'A+B'
         } else if (this.controlSignalInput.value === 3) {
+            // No operation - output 0 to avoid stale data
             this.message = 'ALU'
+            this.output.value = 0
+            simulationArea.simulationQueue.add(this.output)
+            this.carryOut.value = 0
+            simulationArea.simulationQueue.add(this.carryOut)
         } else if (this.controlSignalInput.value === 4) {
             this.message = 'A&~B'
             this.output.value = this.inp1.value & this.flipBits(this.inp2.value)
@@ -165,7 +170,8 @@ export default class ALU extends CircuitElement {
                     (32 - this.bitWidth)) >>>
                 (32 - this.bitWidth)
             simulationArea.simulationQueue.add(this.output)
-            this.carryOut.value = 0
+            // Borrow flag: set to 1 when B > A (borrow occurred)
+            this.carryOut.value = +(this.inp1.value < this.inp2.value)
             simulationArea.simulationQueue.add(this.carryOut)
         } else if (this.controlSignalInput.value === 7) {
             this.message = 'A<B'

--- a/v1/src/simulator/src/modules/ALU.js
+++ b/v1/src/simulator/src/modules/ALU.js
@@ -145,7 +145,12 @@ export default class ALU extends CircuitElement {
             simulationArea.simulationQueue.add(this.output)
             this.message = 'A+B'
         } else if (this.controlSignalInput.value === 3) {
+            // No operation - output 0 to avoid stale data
             this.message = 'ALU'
+            this.output.value = 0
+            simulationArea.simulationQueue.add(this.output)
+            this.carryOut.value = 0
+            simulationArea.simulationQueue.add(this.carryOut)
         } else if (this.controlSignalInput.value === 4) {
             this.message = 'A&~B'
             this.output.value = this.inp1.value & this.flipBits(this.inp2.value)
@@ -165,7 +170,8 @@ export default class ALU extends CircuitElement {
                     (32 - this.bitWidth)) >>>
                 (32 - this.bitWidth)
             simulationArea.simulationQueue.add(this.output)
-            this.carryOut.value = 0
+            // Borrow flag: set to 1 when B > A (borrow occurred)
+            this.carryOut.value = +(this.inp1.value < this.inp2.value)
             simulationArea.simulationQueue.add(this.carryOut)
         } else if (this.controlSignalInput.value === 7) {
             this.message = 'A<B'


### PR DESCRIPTION
Fixes #845 

<!-- Replace XXX with the issue number after you create it -->

## Describe the changes you have made in this PR -

This PR fixes two bugs in the ALU component:

### Bug 1: Subtraction Borrow Flag Always Zero
When performing subtraction (`A-B`, Control Signal = 6), the Carry/Borrow output was hardcoded to `0`. In real hardware, the borrow flag should be `1` when `B > A` to indicate that a borrow occurred.

**Fix:** Changed from 

```javascript 
this.carryOut.value = 0
```
to 

```javascript 
this.carryOut.value = +(this.inp1.value < this.inp2.value)
```

### Bug 2: Control Signal 3 Outputs Stale Data
When Control Signal = 3, the ALU only updated the display message to "ALU" but did not update the output value. This caused the output to retain its previous value (stale data).

**Fix:** Added proper output handling that sets output to `0` and adds both output and carry to the simulation queue.

**Files Modified:**
- [`src/simulator/src/modules/ALU.js`](cci:7://file:///c:/Users/ASUS/OneDrive/Desktop/cv-vue/cv-frontend-vue/src/simulator/src/modules/ALU.js:0:0-0:0)
- [`v1/src/simulator/src/modules/ALU.js`](cci:7://file:///c:/Users/ASUS/OneDrive/Desktop/cv-vue/cv-frontend-vue/v1/src/simulator/src/modules/ALU.js:0:0-0:0)

### Screenshots of the UI changes (If any) -

### Bug 1 fixed : 
<img width="694" height="351" alt="image" src="https://github.com/user-attachments/assets/08ba043a-50b9-4598-bf1a-804b006bba37" />


### Bug 2 fixed :
<img width="747" height="432" alt="image" src="https://github.com/user-attachments/assets/2e42955d-ae60-4301-988d-d9df58d6ed49" />

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

## **Explain your implementation approach:**

**Problem:** The ALU component had two issues affecting simulation correctness:
1. Subtraction never set the borrow flag, making it impossible for downstream circuits to detect underflow
2. Control signal 3 left stale data on the output bus

**Alternative approaches considered:**
- For Bug 1: Could have used `this.inp2.value > this.inp1.value` but `+(a < b)` is more idiomatic JavaScript
- For Bug 2: Could have set output to `undefined`, but `0` is more consistent with hardware behavior (no operation = zero output)

**Why this implementation:**
- Minimal code changes (2 files, ~6 lines each)
- Follows existing patterns in the codebase (other operations use similar carry flag logic)
- Maintains backward compatibility (existing circuits will work, just with correct borrow behavior now)

**Key changes:**
- `this.carryOut.value = +(this.inp1.value < this.inp2.value)` - Sets borrow flag to 1 when B > A
- Added `simulationQueue.add()` calls for CTR=3 to properly propagate output changes

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the no-operation instruction to properly clear outputs and set both result and carry flags to zero.
  * Fixed the subtraction operation to correctly handle the borrow flag, now setting it to indicate when borrowing is required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->