### PR TITLE
fix: Correct Euclidean distance calculation formula

### DIFF
--- a/src/simulator/src/utils.ts
+++ b/src/simulator/src/utils.ts
@@ -71,7 +71,7 @@ export function showMessage(mes: string) {
 }
 
 export function distance(x1: number, y1: number, x2: number, y2: number) {
-    return Math.sqrt((x2 - x1) ** 2) + (y2 - y1) ** 2
+    return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 }
 
 /**

--- a/v1/src/simulator/src/utils.ts
+++ b/v1/src/simulator/src/utils.ts
@@ -71,7 +71,7 @@ export function showMessage(mes: string) {
 }
 
 export function distance(x1: number, y1: number, x2: number, y2: number) {
-    return Math.sqrt((x2 - x1) ** 2) + (y2 - y1) ** 2
+    return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
 }
 
 /**


### PR DESCRIPTION
## Issue Description
Fixed a critical mathematical error in the distance() function in src/simulator/src/utils.ts

## The Bug
The distance calculation had incorrect parentheses:
```
Before: Math.sqrt((x2 - x1) ** 2) + (y2 - y1) ** 2
After:  Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2)
```

The second squared term was outside the square root function.

## Impact
This bug affected any feature that depends on accurate distance calculations including element positioning, wire routing, collision detection, and selection bounds checking.

## Fix
Moved the addition and second squared term inside the sqrt() call to correctly implement the Euclidean distance formula: d = √((x₂-x₁)² + (y₂-y₁)²)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the distance calculation used by the simulator so Euclidean distance is computed properly, improving accuracy of all distance-dependent measurements and behaviors.
  * No public APIs or function signatures were changed; this is an internal accuracy fix with no interface impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->