### PR TITLE
chore: add Vue simulator version dropdown to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -60,7 +60,8 @@ body:
   - type: dropdown
     attributes:
       label: Vue simulator version
-      description: Select the version of the Vue simulator you are using.
+      description: Select the version(s) of the Vue simulator you are using.
+      multiple: true
       options:
         - 'v0'
         - 'v1'


### PR DESCRIPTION

Added a dropdown for selecting the Vue simulator version in the bug report template.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the bug report template to add a required, multi-select "Vue simulator version" dropdown with options v0 and v1, placed before the existing Vue simulator-related question.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->