### PR TITLE
Fix typo in JSDoc comment: 'checkss' should be 'checks'

### DIFF
--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -250,7 +250,7 @@ export function hideProperties() {
     $('.objectPropertyAttribute').unbind('change keyup paste click')
 }
 /**
- * checkss the input is safe or not
+ * checks the input is safe or not
  * @param {HTML} unsafe - the html which we wants to escape
  * @category ux
  */


### PR DESCRIPTION
Fixes #888

## Changes
Fixed the typo in JSDoc comment in src/simulator/src/ux.js:

**Before:**
```javascript
/**
 * checkss the input is safe or not
```

**After:**
```javascript
/**
 * checks the input is safe or not
```

## Type
- Documentation/Comment cleanup
- Good First Issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor documentation corrections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->