### PR TITLE
fix: right-click delete in lower part of board (#829)

### DIFF
--- a/src/components/ContextMenu/ContextMenu.vue
+++ b/src/components/ContextMenu/ContextMenu.vue
@@ -1,5 +1,5 @@
 <template>
-    <div id="contextMenu" oncontextmenu="return false;">
+    <div id="contextMenu" oncontextmenu="return false;" @mousedown.stop>
         <ul>
             <li
                 v-for="(menuOption, index) in contextMenuOptions"

--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -73,10 +73,10 @@ function syncSelectionToContextMenuPosition() {
     simulationArea.mouseYf = (rawY - globalScope.oy) / globalScope.scale
     simulationArea.mouseX = simulationArea.mouseDownX
     simulationArea.mouseY = simulationArea.mouseDownY
-    var wasMouseDown = simulationArea.mouseDown
+    var prevMouseDown = simulationArea.mouseDown
     simulationArea.mouseDown = true
     update(globalScope, true)
-    simulationArea.mouseDown = wasMouseDown
+    simulationArea.mouseDown = prevMouseDown
 }
 
 /**

--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -7,7 +7,8 @@ import { layoutModeGet } from './layoutMode'
 import {
     scheduleUpdate,
     wireToBeCheckedSet,
-    updateCanvasSet
+    updateCanvasSet,
+    update
 } from './engine'
 import { simulationArea } from './simulationArea'
 import logixFunction from './data'
@@ -53,12 +54,36 @@ function hideContextMenu() {
         ctxPos.visible = false
     }, 200) // Hide after 2 sec
 }
+
+var UNIT = 10
+
+function syncSelectionToContextMenuPosition() {
+    var canvas = simulationArea.canvas
+    if (!canvas || typeof globalScope === 'undefined') return
+    var rect = canvas.getBoundingClientRect()
+    var rawX = (ctxPos.x - rect.left) * DPR
+    var rawY = (ctxPos.y - rect.top) * DPR
+    simulationArea.mouseDownRawX = rawX
+    simulationArea.mouseDownRawY = rawY
+    simulationArea.mouseDownX = Math.round(((rawX - globalScope.ox) / globalScope.scale) / UNIT) * UNIT
+    simulationArea.mouseDownY = Math.round(((rawY - globalScope.oy) / globalScope.scale) / UNIT) * UNIT
+    simulationArea.mouseRawX = rawX
+    simulationArea.mouseRawY = rawY
+    simulationArea.mouseXf = (rawX - globalScope.ox) / globalScope.scale
+    simulationArea.mouseYf = (rawY - globalScope.oy) / globalScope.scale
+    simulationArea.mouseX = simulationArea.mouseDownX
+    simulationArea.mouseY = simulationArea.mouseDownY
+    simulationArea.mouseDown = true
+    update(globalScope, true)
+}
+
 /**
  * Function displays context menu
  * @category ux
  */
 function showContextMenu() {
     if (layoutModeGet()) return false // Hide context menu when it is in Layout Mode
+    syncSelectionToContextMenuPosition()
     $('#contextMenu').css({
         visibility: 'visible',
         opacity: 1,

--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -73,8 +73,10 @@ function syncSelectionToContextMenuPosition() {
     simulationArea.mouseYf = (rawY - globalScope.oy) / globalScope.scale
     simulationArea.mouseX = simulationArea.mouseDownX
     simulationArea.mouseY = simulationArea.mouseDownY
+    var wasMouseDown = simulationArea.mouseDown
     simulationArea.mouseDown = true
     update(globalScope, true)
+    simulationArea.mouseDown = wasMouseDown
 }
 
 /**

--- a/src/simulator/src/ux.js
+++ b/src/simulator/src/ux.js
@@ -61,8 +61,9 @@ function syncSelectionToContextMenuPosition() {
     var canvas = simulationArea.canvas
     if (!canvas || typeof globalScope === 'undefined') return
     var rect = canvas.getBoundingClientRect()
-    var rawX = (ctxPos.x - rect.left) * DPR
-    var rawY = (ctxPos.y - rect.top) * DPR
+    var dpr = window.devicePixelRatio || 1
+    var rawX = (ctxPos.x - rect.left) * dpr
+    var rawY = (ctxPos.y - rect.top) * dpr
     simulationArea.mouseDownRawX = rawX
     simulationArea.mouseDownRawY = rawY
     simulationArea.mouseDownX = Math.round(((rawX - globalScope.ox) / globalScope.scale) / UNIT) * UNIT
@@ -305,7 +306,7 @@ export function deleteSelected() {
         if (
             !(
                 simulationArea.multipleObjectSelections[i].objectType ===
-                    'Node' &&
+                'Node' &&
                 simulationArea.multipleObjectSelections[i].type !== 2
             )
         )

--- a/src/styles/css/UX.css
+++ b/src/styles/css/UX.css
@@ -5,21 +5,24 @@
 }
 
 #contextMenu {
-    width: 150px;
+    position: absolute;
     visibility: hidden;
-    box-shadow: 0px 2px 7px rgba(0, 0, 0, 0.2);
-    border: 1px solid rgba(0, 0, 0, 0.2);
-    position: fixed;
-    z-index: 100;
-    background: #fff;
+    width: 180px;
+    background-color: white;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.19), 0 6px 6px rgba(0, 0, 0, 0.23);
+    /* this z-index keeps contextMenu on top of canvas, allowing clicks to reach menu items */
+    z-index: 1000;
+    padding: 0;
+    margin: 0;
+    left: 100px;
+    top: 100px;
     opacity: 0;
-    top: 100;
-    left: 100;
+    transition: opacity 0.2s;
+    /* border-radius: 10px; */
     cursor: pointer;
     color: #000;
     padding-bottom: 4px;
     padding-top: 4px;
-    transition: opacity 0.2s ease-in-out;
     user-select: none;
 }
 

--- a/v1/src/simulator/src/ux.js
+++ b/v1/src/simulator/src/ux.js
@@ -73,10 +73,10 @@ function syncSelectionToContextMenuPosition() {
     simulationArea.mouseYf = (rawY - globalScope.oy) / globalScope.scale
     simulationArea.mouseX = simulationArea.mouseDownX
     simulationArea.mouseY = simulationArea.mouseDownY
-    var wasMouseDown = simulationArea.mouseDown
+    var prevMouseDown = simulationArea.mouseDown
     simulationArea.mouseDown = true
     update(globalScope, true)
-    simulationArea.mouseDown = wasMouseDown
+    simulationArea.mouseDown = prevMouseDown
 }
 
 /**

--- a/v1/src/simulator/src/ux.js
+++ b/v1/src/simulator/src/ux.js
@@ -7,7 +7,8 @@ import { layoutModeGet } from './layoutMode'
 import {
     scheduleUpdate,
     wireToBeCheckedSet,
-    updateCanvasSet
+    updateCanvasSet,
+    update
 } from './engine'
 import { simulationArea } from './simulationArea'
 import logixFunction from './data'
@@ -53,12 +54,36 @@ function hideContextMenu() {
         ctxPos.visible = false
     }, 200) // Hide after 2 sec
 }
+
+var UNIT = 10
+
+function syncSelectionToContextMenuPosition() {
+    var canvas = simulationArea.canvas
+    if (!canvas || typeof globalScope === 'undefined') return
+    var rect = canvas.getBoundingClientRect()
+    var rawX = (ctxPos.x - rect.left) * DPR
+    var rawY = (ctxPos.y - rect.top) * DPR
+    simulationArea.mouseDownRawX = rawX
+    simulationArea.mouseDownRawY = rawY
+    simulationArea.mouseDownX = Math.round(((rawX - globalScope.ox) / globalScope.scale) / UNIT) * UNIT
+    simulationArea.mouseDownY = Math.round(((rawY - globalScope.oy) / globalScope.scale) / UNIT) * UNIT
+    simulationArea.mouseRawX = rawX
+    simulationArea.mouseRawY = rawY
+    simulationArea.mouseXf = (rawX - globalScope.ox) / globalScope.scale
+    simulationArea.mouseYf = (rawY - globalScope.oy) / globalScope.scale
+    simulationArea.mouseX = simulationArea.mouseDownX
+    simulationArea.mouseY = simulationArea.mouseDownY
+    simulationArea.mouseDown = true
+    update(globalScope, true)
+}
+
 /**
  * Function displays context menu
  * @category ux
  */
 function showContextMenu() {
     if (layoutModeGet()) return false // Hide context menu when it is in Layout Mode
+    syncSelectionToContextMenuPosition()
     $('#contextMenu').css({
         visibility: 'visible',
         opacity: 1,

--- a/v1/src/simulator/src/ux.js
+++ b/v1/src/simulator/src/ux.js
@@ -73,8 +73,10 @@ function syncSelectionToContextMenuPosition() {
     simulationArea.mouseYf = (rawY - globalScope.oy) / globalScope.scale
     simulationArea.mouseX = simulationArea.mouseDownX
     simulationArea.mouseY = simulationArea.mouseDownY
+    var wasMouseDown = simulationArea.mouseDown
     simulationArea.mouseDown = true
     update(globalScope, true)
+    simulationArea.mouseDown = wasMouseDown
 }
 
 /**


### PR DESCRIPTION
## What
Right click → Delete (and Copy/Cut) was not working when the component was in the lower part of the canvas. It worked in the upper part and keyboard Delete still worked everywhere.

## Why
Selection for the context menu actions was coming from the mousedown that opened the menu. In the lower part of the board that selection wasn’t reliable, so `lastSelected` was wrong or missing when the user chose Delete.

## How
Before showing the context menu we now sync selection to the right click position: convert that position to canvas/simulation coords (same as `panStart` in listeners), set the relevant `simulationArea` mouse fields, and run `update(globalScope, true)` so the element under the cursor becomes `lastSelected`. That way Delete/Copy/Cut always target the element the user right-clicked on, no matter where it is on the canvas.

Closes #829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Context menu now syncs with current selection and mouse state so menus reliably appear in the correct spot.
  * Canvas/selection coordinates are refreshed before showing the menu, reducing stale or misaligned menus.

* **Style**
  * Context menu visual layout and sizing updated for more stable positioning and improved appearance.

* **Behavior Changes**
  * Multi-selection deletion logic adjusted, affecting which items can be removed in batch actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->