### PR TITLE
Fix: Use strict equality in circuit selection

### DIFF
--- a/src/simulator/src/circuit.ts
+++ b/src/simulator/src/circuit.ts
@@ -102,7 +102,7 @@ export function switchCircuit(id: string) {
         // $(`#${id}`).addClass('current')
         const index = circuit_list.value.findIndex(
             (circuit) => circuit.id === id
-        ) // TODO: add strict equality after typescript
+        )
         circuit_list.value[index].focussed = true
         if (activeCircuit.value) {
             activeCircuit.value.id = globalScope.id


### PR DESCRIPTION
Change loose equality (==) to strict equality (===) in the findIndex for circuit selection to prevent type coercion issues that could cause incorrect circuit focusing.

Fixes #898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circuit selection reliability to ensure circuits are correctly identified and switched without potential matching errors.
  * Reduces rare mismatches during circuit switching, improving consistency when selecting a specific circuit.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->