### PR TITLE
Refactor: Consolidate duplicate dec2bin utility implementations

### DIFF
--- a/src/simulator/src/modules/ConstantVal.js
+++ b/src/simulator/src/modules/ConstantVal.js
@@ -3,17 +3,7 @@ import Node, { findNode } from '../node'
 import { simulationArea } from '../simulationArea'
 import { correctWidth, rect2, fillText, oppositeDirection } from '../canvasApi'
 import { colors } from '../themer/themer'
-
-function bin2dec(binString) {
-    return parseInt(binString, 2)
-}
-
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin, bin2dec } from '../node'
 
 /**
  * @class

--- a/src/simulator/src/modules/Input.js
+++ b/src/simulator/src/modules/Input.js
@@ -18,17 +18,7 @@ import { generateId } from '../utils'
  * @category modules
  */
 import { colors } from '../themer/themer'
-
-function bin2dec(binString) {
-    return parseInt(binString, 2)
-}
-
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin, bin2dec } from '../node'
 
 export default class Input extends CircuitElement {
     constructor(

--- a/src/simulator/src/modules/Output.js
+++ b/src/simulator/src/modules/Output.js
@@ -5,17 +5,7 @@ import { correctWidth, fillText, rect2, oppositeDirection } from '../canvasApi'
 import { getNextPosition } from '../modules'
 import { generateId } from '../utils'
 import { colors } from '../themer/themer'
-
-function bin2dec(binString) {
-    return parseInt(binString, 2)
-}
-
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin } from '../node'
 
 /**
  * @class

--- a/src/simulator/src/testbench/testbenchOutput.js
+++ b/src/simulator/src/testbench/testbenchOutput.js
@@ -2,14 +2,7 @@ import CircuitElement from '../circuitElement'
 import { simulationArea } from '../simulationArea'
 import { correctWidth, fillText } from '../canvasApi'
 import Node, { findNode } from '../node'
-
-// helper function to convert decimal to binary
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin } from '../node'
 
 /**
  * TestBench Output has a node for it's  input which is

--- a/v1/src/simulator/src/modules/ConstantVal.js
+++ b/v1/src/simulator/src/modules/ConstantVal.js
@@ -3,17 +3,7 @@ import Node, { findNode } from '../node'
 import { simulationArea } from '../simulationArea'
 import { correctWidth, rect2, fillText, oppositeDirection } from '../canvasApi'
 import { colors } from '../themer/themer'
-
-function bin2dec(binString) {
-    return parseInt(binString, 2)
-}
-
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin, bin2dec } from '../node'
 
 /**
  * @class

--- a/v1/src/simulator/src/modules/Input.js
+++ b/v1/src/simulator/src/modules/Input.js
@@ -18,17 +18,7 @@ import { generateId } from '../utils'
  * @category modules
  */
 import { colors } from '../themer/themer'
-
-function bin2dec(binString) {
-    return parseInt(binString, 2)
-}
-
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin, bin2dec } from '../node'
 
 export default class Input extends CircuitElement {
     constructor(

--- a/v1/src/simulator/src/modules/Output.js
+++ b/v1/src/simulator/src/modules/Output.js
@@ -5,17 +5,7 @@ import { correctWidth, fillText, rect2, oppositeDirection } from '../canvasApi'
 import { getNextPosition } from '../modules'
 import { generateId } from '../utils'
 import { colors } from '../themer/themer'
-
-function bin2dec(binString) {
-    return parseInt(binString, 2)
-}
-
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin } from '../node'
 
 /**
  * @class

--- a/v1/src/simulator/src/testbench/testbenchOutput.js
+++ b/v1/src/simulator/src/testbench/testbenchOutput.js
@@ -2,14 +2,7 @@ import CircuitElement from '../circuitElement'
 import { simulationArea } from '../simulationArea'
 import { correctWidth, fillText } from '../canvasApi'
 import Node, { findNode } from '../node'
-
-// helper function to convert decimal to binary
-function dec2bin(dec, bitWidth = undefined) {
-    // only for positive nos
-    var bin = dec.toString(2)
-    if (bitWidth == undefined) return bin
-    return '0'.repeat(bitWidth - bin.length) + bin
-}
+import { dec2bin } from '../node'
 
 /**
  * TestBench Output has a node for it's  input which is


### PR DESCRIPTION
I noticed we had the same `dec2bin` logic copy pasted in several places, even though we already have a shared version exported from `node.js`.

This PR cleans that up by removing the local duplicates in `Input.js`, `Output.js`, `ConstantVal.js`, and `testbenchOutput.js` and importing the shared utility instead.

**Changes:**
- Removed local `dec2bin` function from `Input.js`, `Output.js`, `ConstantVal.js`, and `testbench/testbenchOutput.js`.
- Imported `dec2bin` from `../node` in these files.
- Left the implementation in `testbench.ts` alone since it handles undefined values differently.

**Verification:**
- Ran the build (`npm run build`) - passed.
- Functionality should remain exactly the same as the logic was identical.

Fixes #905

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated binary/decimal conversion helpers into a shared utility used across simulator modules and testbench.
  * Removed duplicated in-file implementations; components now rely on the common converter.
  * No user-facing behavior changes expected; input/output displays and testbench output should behave as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->