### PR TITLE
Fix Euclidean distance calculation in pinch to zoom logic

### DIFF
--- a/src/simulator/spec/pinchZoom.spec.js
+++ b/src/simulator/spec/pinchZoom.spec.js
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { pinchZoom } from '../src/listeners';
+
+vi.mock('../src/simulationArea', () => ({ simulationArea: { canvas: { getBoundingClientRect: vi.fn(() => ({ left: 0, top: 0, width: 100, height: 100 })) } } }));
+vi.mock('../src/engine', () => ({ gridUpdateSet: vi.fn(), scheduleUpdate: vi.fn(), updateSimulationSet: vi.fn(), updatePositionSet: vi.fn(), updateCanvasSet: vi.fn(), wireToBeCheckedSet: vi.fn(), errorDetectedSet: vi.fn() }));
+vi.mock('../src/layoutMode', () => ({ layoutModeGet: vi.fn(), tempBuffer: {}, layoutUpdate: vi.fn() }));
+vi.mock('../src/canvasApi', () => ({ changeScale: vi.fn(), findDimensions: vi.fn() }));
+vi.mock('../src/data/backupCircuit', () => ({ scheduleBackup: vi.fn() }));
+vi.mock('../src/ux', () => ({ hideProperties: vi.fn(), deleteSelected: vi.fn(), uxvar: {}, exitFullView: vi.fn() }));
+vi.mock('../src/restrictedElementDiv', () => ({ updateRestrictedElementsList: vi.fn(), updateRestrictedElementsInScope: vi.fn(), hideRestricted: vi.fn(), showRestricted: vi.fn() }));
+vi.mock('../src/minimap', () => ({ removeMiniMap: vi.fn(), updatelastMinimapShown: vi.fn() }));
+vi.mock('../src/data/undo', () => ({ default: vi.fn() }));
+vi.mock('../src/data/redo', () => ({ default: vi.fn() }));
+vi.mock('../src/events', () => ({ copy: vi.fn(), paste: vi.fn(), selectAll: vi.fn() }));
+vi.mock('../src/Verilog2CV', () => ({ verilogModeGet: vi.fn() }));
+vi.mock('../src/plotArea', () => ({ setupTimingListeners: vi.fn() }));
+vi.mock('../src/data', () => ({ default: {} }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('#/store/simulatorMobileStore', () => ({ useSimulatorMobileStore: vi.fn() }));
+vi.mock('vue', () => ({ toRefs: vi.fn() }));
+
+describe('pinchZoom', () => {
+    let globalScope = { scale: 1, ox: 0, oy: 0, root: {} };
+    beforeEach(() => { globalScope.scale = 1; global.DPR = 1; });
+    it('increases scale on zoom', () => {
+        pinchZoom({ preventDefault: vi.fn(), touches: [{ clientX: 0, clientY: 0 }, { clientX: 10, clientY: 0 }] }, globalScope);
+        expect(globalScope.scale).toBe(1.5);
+        pinchZoom({ preventDefault: vi.fn(), touches: [{ clientX: 0, clientY: 0 }, { clientX: 8, clientY: 10 }] }, globalScope);
+        expect(globalScope.scale).toBe(1.6);
+    });
+});

--- a/src/simulator/spec/vitestSetup.ts
+++ b/src/simulator/spec/vitestSetup.ts
@@ -1,22 +1,23 @@
 import { vi, afterEach } from 'vitest';
 
-global.window = window;
-global.jQuery = require('jquery');
-global.DPR = true;
-global.width = true;
-global.height = true;
+(global as any).window = window;
+(global as any).jQuery = require('jquery');
+(global as any).DPR = 1;
+(global as any).width = 100;
+(global as any).height = 100;
 
-window.Jquery = require('jquery');
-window.$ = require('jquery');
-window.restrictedElements = [];
-window.userSignedIn = true;
-window.embed = false;
+(window as any).Jquery = require('jquery');
+(window as any).$ = require('jquery');
+(window as any).restrictedElements = [];
+(window as any).userSignedIn = true;
+(window as any).embed = false;
 
 vi.useFakeTimers()
 
 afterEach(() => {
 	vi.runOnlyPendingTimers()
 	vi.clearAllTimers()
+    window.localStorage.clear();
 })
 
 vi.mock('@tauri-apps/api/event', () => ({
@@ -30,16 +31,14 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
 }))
 
 HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
-    clearRect: vi.fn(),
-    fillRect: vi.fn(),
-    fillText: vi.fn(),
-    strokeRect: vi.fn(),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    stroke: vi.fn(),
-    closePath: vi.fn(),
-    arc: vi.fn(),
-    fill: vi.fn(),
-    rect: vi.fn(),
-})) 
+    clearRect: vi.fn(), fillRect: vi.fn(), fillText: vi.fn(), strokeRect: vi.fn(), beginPath: vi.fn(),
+    moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(), closePath: vi.fn(), arc: vi.fn(), fill: vi.fn(), rect: vi.fn(),
+} as unknown as CanvasRenderingContext2D)) as any
+
+Object.defineProperty(window, 'localStorage', { value: {
+  _s: {} as Record<string, string>,
+  getItem(k: string) { return this._s[k] || null; },
+  setItem(k: string, v: string) { this._s[k] = String(v); },
+  removeItem(k: string) { delete this._s[k]; },
+  clear() { this._s = {}; }
+}});

--- a/src/simulator/src/listeners.js
+++ b/src/simulator/src/listeners.js
@@ -12,6 +12,7 @@ import {
     tempBuffer,
     layoutUpdate,
 } from './layoutMode'
+import { distance as euclideanDistance } from './utils'
 import { simulationArea } from './simulationArea'
 import {
     scheduleUpdate,
@@ -123,7 +124,7 @@ export function pinchZoom(e, globalScope) {
     updatePositionSet(true);
     updateCanvasSet(true);
     // Calculating distance between touch to see if its pinchIN or pinchOut
-    distance = Math.sqrt((e.touches[1].clientX - e.touches[0].clientX) ** 2, (e.touches[1].clientY - e.touches[0].clientY) ** 2);
+    distance = euclideanDistance(e.touches[0].clientX, e.touches[0].clientY, e.touches[1].clientX, e.touches[1].clientY);
     if (distance >= currDistance) {
         pinchZ += 0.02;
         currDistance = distance;

--- a/v1/src/simulator/spec/vitestSetup.ts
+++ b/v1/src/simulator/spec/vitestSetup.ts
@@ -1,22 +1,23 @@
 import { vi, afterEach } from 'vitest';
 
-global.window = window;
-global.jQuery = require('jquery');
-global.DPR = true;
-global.width = true;
-global.height = true;
+(global as any).window = window;
+(global as any).jQuery = require('jquery');
+(global as any).DPR = 1;
+(global as any).width = 100;
+(global as any).height = 100;
 
-window.Jquery = require('jquery');
-window.$ = require('jquery');
-window.restrictedElements = [];
-window.userSignedIn = true;
-window.embed = false;
+(window as any).Jquery = require('jquery');
+(window as any).$ = require('jquery');
+(window as any).restrictedElements = [];
+(window as any).userSignedIn = true;
+(window as any).embed = false;
 
 vi.useFakeTimers()
 
 afterEach(() => {
 	vi.runOnlyPendingTimers()
 	vi.clearAllTimers()
+    window.localStorage.clear();
 })
 
 vi.mock('@tauri-apps/api/event', () => ({
@@ -30,16 +31,14 @@ global.ResizeObserver = vi.fn().mockImplementation(() => ({
 }))
 
 HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
-    clearRect: vi.fn(),
-    fillRect: vi.fn(),
-    fillText: vi.fn(),
-    strokeRect: vi.fn(),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    stroke: vi.fn(),
-    closePath: vi.fn(),
-    arc: vi.fn(),
-    fill: vi.fn(),
-    rect: vi.fn(),
-})) 
+    clearRect: vi.fn(), fillRect: vi.fn(), fillText: vi.fn(), strokeRect: vi.fn(), beginPath: vi.fn(),
+    moveTo: vi.fn(), lineTo: vi.fn(), stroke: vi.fn(), closePath: vi.fn(), arc: vi.fn(), fill: vi.fn(), rect: vi.fn(),
+} as unknown as CanvasRenderingContext2D)) as any
+
+Object.defineProperty(window, 'localStorage', { value: {
+  _s: {} as Record<string, string>,
+  getItem(k: string) { return this._s[k] || null; },
+  setItem(k: string, v: string) { this._s[k] = String(v); },
+  removeItem(k: string) { delete this._s[k]; },
+  clear() { this._s = {}; }
+}});

--- a/v1/src/simulator/src/listeners.js
+++ b/v1/src/simulator/src/listeners.js
@@ -12,6 +12,7 @@ import {
     tempBuffer,
     layoutUpdate,
 } from './layoutMode'
+import { distance as euclideanDistance } from './utils'
 import { simulationArea } from './simulationArea'
 import {
     scheduleUpdate,
@@ -123,7 +124,7 @@ export function pinchZoom(e, globalScope) {
     updatePositionSet(true);
     updateCanvasSet(true);
     // Calculating distance between touch to see if its pinchIN or pinchOut
-    distance = Math.sqrt((e.touches[1].clientX - e.touches[0].clientX) ** 2, (e.touches[1].clientY - e.touches[0].clientY) ** 2);
+    distance = euclideanDistance(e.touches[0].clientX, e.touches[0].clientY, e.touches[1].clientX, e.touches[1].clientY);
     if (distance >= currDistance) {
         pinchZ += 0.02;
         currDistance = distance;


### PR DESCRIPTION
This PR fixes a bug in the pinch to zoom gesture handler where the Euclidean distance was being calculated incorrectly. The `Math.sqrt` function was being passed two separate arguments instead of the sum of squared differences, which caused inaccurate zoom behavior.

**Key Changes:**
- Corrected the distance formula in `src/simulator/src/listeners.js` and the v1 equivalent.
- Added a new unit test `pinchZoom.spec.js` to verify the fix and prevent regressions.
- Updated `vitestSetup.ts` with a lightweight `localStorage` mock to resolve test environment failures.

**Related Issue:**
Fixes #860

**Verification:**
- Added a specific test case that confirms the scale increases correctly when the touch distance expands.
- Verified that all existing tests pass with the updated setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected pinch-zoom distance calculation so pinch gestures produce accurate, consistent zoom behavior.

* **Tests**
  * Added automated pinch-zoom tests verifying scale progression across gestures.
  * Improved test setup with safer global mocks and an in-memory localStorage that is cleared between tests to stabilize runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->