### PR TITLE
Resolve v1 drag-and-drop functionality by fixing module initialization

### DIFF
--- a/src/styles/tutorials.scss
+++ b/src/styles/tutorials.scss
@@ -1,4 +1,4 @@
-@import '/node_modules/driver.js/dist/driver.min.css';
+@import '../../node_modules/driver.js/dist/driver.min.css';
 
 #driver-highlighted-element-stage {
     background-color: transparent !important;

--- a/v1/src/styles/tutorials.scss
+++ b/v1/src/styles/tutorials.scss
@@ -1,4 +1,4 @@
-@import '/node_modules/driver.js/dist/driver.min.css';
+@import '../../../node_modules/driver.js/dist/driver.min.css';
 
 #driver-highlighted-element-stage {
     background-color: transparent !important;
@@ -7,7 +7,7 @@
 .driver-disabled {
     border: 1.5px solid #ddd !important;
 }
-
+    
 .driver-btn-group button {
     font-family: 'Nunito', sans-serif !important;
     font-size: 14px !important;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig(() => {
         },
         base: process.env.VITE_BASE || (isDesktop ? '/' : `/simulatorvue/${version}/`),
         build: {
-            outDir: `./dist/simulatorvue/${version}/`,
+            outDir: `../dist/simulatorvue/${version}/`,
             assetsDir: 'assets',
             chunkSizeWarningLimit: 1600,
             rollupOptions: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig(() => {
     const isDesktop = !!process.env.DESKTOP_MODE
 
     return {
+         root: `./${version}`,
+
         plugins: [
             vue(),
             vuetify({ autoImport: true }),
@@ -58,6 +60,9 @@ export default defineConfig(() => {
         },
         server: {
             port: 4000,
+            fs: {
+                allow: ['..']
+            }
         },
         preview: {
             port: 4173,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,71 +1,64 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
-import { fileURLToPath, URL } from 'url'
-import vueI18n from '@intlify/vite-plugin-vue-i18n'
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import { fileURLToPath, URL } from "url";
+import vueI18n from "@intlify/vite-plugin-vue-i18n";
 
 // https://github.com/vuetifyjs/vuetify-loader/tree/next/packages/vite-plugin
-import vuetify from 'vite-plugin-vuetify'
-import { createHtmlPlugin } from 'vite-plugin-html'
+import vuetify from "vite-plugin-vuetify";
+import { createHtmlPlugin } from "vite-plugin-html";
 
-import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js'
+import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 
 // https://vitejs.dev/config/
 export default defineConfig(() => {
-    const version = process.env.VITE_SIM_VERSION || 'v0'
-    const isDesktop = !!process.env.DESKTOP_MODE
+  const version = process.env.VITE_SIM_VERSION || "v0";
+  const isDesktop = !!process.env.DESKTOP_MODE;
 
-    return {
-         root: `./${version}`,
+  return {
+    root: `./${version}`,
+    plugins: [
+      vue(),
+      vuetify({ autoImport: true }),
+      cssInjectedByJsPlugin(),
+      vueI18n({
+        // if you want to use Vue I18n Legacy API, you need to set `compositionOnly: false`
+        // compositionOnly: false,
 
-        plugins: [
-            vue(),
-            vuetify({ autoImport: true }),
-            cssInjectedByJsPlugin(),
-            vueI18n({
-                // if you want to use Vue I18n Legacy API, you need to set `compositionOnly: false`
-                // compositionOnly: false,
-
-                // you need to set i18n resource including paths !
-                include: fileURLToPath(
-                    new URL(`./${version}/src/locales/**`, import.meta.url)
-                ),
-            }),
-        ],
-        resolve: {
-            alias: {
-                '#': fileURLToPath(new URL(`./${version}/src`, import.meta.url)),
-                '@': fileURLToPath(
-                    new URL(`./${version}/src/components`, import.meta.url)
-                ),
-            },
+        // you need to set i18n resource including paths !
+        include: fileURLToPath(new URL(`./${version}/src/locales/**`, import.meta.url)),
+      }),
+    ],
+    resolve: {
+      alias: {
+        "#": fileURLToPath(new URL(`./${version}/src`, import.meta.url)),
+        "@": fileURLToPath(new URL(`./${version}/src/components`, import.meta.url)),
+      },
+    },
+    base: process.env.VITE_BASE || (isDesktop ? "/" : `/simulatorvue/${version}/`),
+    build: {
+      outDir: `../dist/simulatorvue/${version}/`,
+      assetsDir: "assets",
+      chunkSizeWarningLimit: 1600,
+      rollupOptions: {
+        input: {
+          main: fileURLToPath(new URL(`./${version}/index.html`, import.meta.url)),
         },
-        base: process.env.VITE_BASE || (isDesktop ? '/' : `/simulatorvue/${version}/`),
-        build: {
-            outDir: `../dist/simulatorvue/${version}/`,
-            assetsDir: 'assets',
-            chunkSizeWarningLimit: 1600,
-            rollupOptions: {
-                input: {
-                    main: fileURLToPath(
-                        new URL(`./${version}/index.html`, import.meta.url)
-                    ),
-                },
-                output: {
-                    entryFileNames: `simulator-${version}.js`,
-                    chunkFileNames: `assets/[name].js`,
-                    assetFileNames: `assets/[name].[ext]`,
-                },
-            },
+        output: {
+          entryFileNames: `simulator-${version}.js`,
+          chunkFileNames: `assets/[name].js`,
+          assetFileNames: `assets/[name].[ext]`,
         },
-        server: {
-            port: 4000,
-            fs: {
-                allow: ['..']
-            }
-        },
-        preview: {
-            port: 4173,
-        },
-    }
-})
+      },
+    },
+    server: {
+      port: 4000,
+      fs: {
+          allow: ['..']
+       }
+    },
+    preview: {
+      port: 4173,
+    },
+  };
+});


### PR DESCRIPTION

Fixes #922 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR
This PR fixes the drag-and-drop functionality in v1 that was broken due to incorrect module loading. The root cause was that v0's main.ts file was being loaded instead of v1's main.ts, which meant the circuit element modules were never properly initialized before components tried to use them.
<img width="1500" height="311" alt="image" src="https://github.com/user-attachments/assets/cd22385d-23a0-45b0-bbb0-29b0586f6885" />


**Changes made:**
- Set Vite root to version-specific directory to ensure correct file loading
- Update CSS import path in tutorials.scss to work with new root
- Add filesystem access permission for parent directory in dev server
- This fixes the issue where v0's files were loading instead of v1's files
- Resolves drag-and-drop elements not working in v1 due to uninitialized modules

### Screenshots of the UI changes (If any)
Before: Drag-and-drop not working, console errors when hovering/clicking circuit elements
<img width="1500" height="311" alt="image" src="https://github.com/user-attachments/assets/4b5a06dc-3edb-46ee-bec2-f934e6284c38" />

After: Drag-and-drop working correctly
<img width="1528" height="351" alt="image" src="https://github.com/user-attachments/assets/1558c2c8-a260-40af-b2e6-57abff404efe" />


<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** When running v1 of the simulator, the drag-and-drop functionality for circuit elements was completely broken. The browser console showed errors like "modules[elementName] is not a constructor" and "Cannot read properties of undefined (reading 'prototype')".

**Root Cause Analysis:** Through debugging, I discovered that v0's main.ts file was being loaded instead of v1's main.ts (confirmed via import.meta.url showing `/simulatorvue/v1/v0/src/main.ts`). This happened because Vite was resolving file paths from the project root, causing the path aliases (#/ and @/) to incorrectly point to v0's source files even when VITE_SIM_VERSION was set to "v1".

**Testing:**
- Verified v1 loads correctly and drag-and-drop works
- Confirmed v0 still works as expected
- Tested that modules are properly initialized before components mount
- Checked build output paths are correct

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted stylesheet dependency import paths for more reliable asset resolution.
  * Updated build and dev server configuration to align output with versioned site structure and improve asset routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->