### PR TITLE
feat(simulation): add explicit post-stabilization hook at end of play()

### DIFF
--- a/src/simulator/src/engine.js
+++ b/src/simulator/src/engine.js
@@ -440,6 +440,7 @@ export function play(scope = globalScope, resetNodes = false) {
         }
     }
     // Check for Contentions
+    let hadContention = false;
     if (simulationArea.contentionPending.size() > 0) {
         for (const [ourNode, theirNode] of simulationArea.contentionPending.nodes()) {
             ourNode.highlighted = true;
@@ -448,10 +449,13 @@ export function play(scope = globalScope, resetNodes = false) {
 
         forceResetNodesSet(true);
         showError('Contention Error: One or more bus contentions in the circuit (check highlighted nodes)');
+        hadContention = true;
     }
-// Post-stabilization hook: simulation queue drained, state fully resolved
-onSimulationStabilized(scope);
+// Post-stabilization hook: only when queue drained cleanly
+if (!hadContention) {
+    onSimulationStabilized(scope);
 
+}
 }
 
 export function resetNodeHighlights(scope) {

--- a/src/simulator/src/engine.js
+++ b/src/simulator/src/engine.js
@@ -449,11 +449,30 @@ export function play(scope = globalScope, resetNodes = false) {
         forceResetNodesSet(true);
         showError('Contention Error: One or more bus contentions in the circuit (check highlighted nodes)');
     }
+// Post-stabilization hook: simulation queue drained, state fully resolved
+onSimulationStabilized(scope);
+
 }
 
 export function resetNodeHighlights(scope) {
     for (const node of scope.allNodes) node.highlighted = false;
 }
+
+/**
+ * Internal hook invoked once after the simulation queue has been fully drained
+ * and the circuit has reached a stabilized state for the current tick.
+ *
+ * This provides an explicit post-tick boundary for future debugging,
+ * deterministic snapshotting, and runtime instrumentation layers.
+ *
+ * The function is intentionally a no-op and does not modify simulation behavior.
+ *
+ * @param {Scope} scope
+ */
+function onSimulationStabilized(scope) {
+    // intentionally empty
+}
+
 
 /**
  * Function to check for any UI update, it is throttled by time


### PR DESCRIPTION
Fixes #

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR
This PR generally focuses on how to know whether the state is stable or not. Before this PR, there was no way to determine at what point exactly the circuit is stabilized, which means there was not any explicit function that determines the stabilization of the state.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)


**Explain your implementation approach:**

Describe in your own words:
- This is a no-op code that solves the problem of knowing when the current state is stable.
- I chose this because it adds reusable code that is specific and clear and adds an explicit function to define the end of a particular state, which makes future debugging easier and reliable.
- Added the hook after the queue is completely drained, all resolve operations are finished, contention checks have completed, and the function is completely stable; this avoids the conflict of logic between the previous code.

<!-- 
This helps reviewers understand your thought process and ensures you understand the code.
-->

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added internal stabilization callback infrastructure to the simulator to enable future extensibility of the simulation lifecycle. This introduces a post-tick boundary hook used internally; there are no user-facing behavior changes or API surface modifications in this release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->