### PR TITLE
docs: fix toggle typo in simulator stylesheet comment

### DIFF
--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -975,7 +975,7 @@ div.icon img {
     border-radius: 3px !important;
 }
 
-/* toogle */
+/* toggle */
 
 .switch {
     position: relative;

--- a/v1/src/styles/css/main.stylesheet.css
+++ b/v1/src/styles/css/main.stylesheet.css
@@ -975,7 +975,7 @@ div.icon img {
     border-radius: 3px !important;
 }
 
-/* toogle */
+/* toggle */
 
 .switch {
     position: relative;


### PR DESCRIPTION
Fixes #952

Updated the section comment in src/styles/css/main.stylesheet.css and v1/src/styles/css/main.stylesheet.css from toogle to toggle. This is a docs/comment-only cleanup to keep terminology consistent across both paths.

How to verify: open both files and confirm the comment above .switch reads toggle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed a minor typo in CSS documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->