### PR TITLE
docs: fix shortcut spelling in hotkey documentation

### DIFF
--- a/src/simulator/src/hotkey_binder/documentation.txt
+++ b/src/simulator/src/hotkey_binder/documentation.txt
@@ -29,13 +29,13 @@ MAIN FILEs:
     * Others
 
 USAGE:
-    TO ADD SHORCUTS:
+    TO ADD SHORTCUTS:
         #1 add the shortcut in the defaultKeys.json file
-        #2 Assign the callback in addShorcut.js:
+        #2 Assign the callback in addShortcut.js:
             * the callback should be a func reference,if function to be invoked is already defined in the codebase just set it as it is. (for some func reference may not work, refer next step)
 
             *for callback not present in the codebase, or is present but doesn't work as intended, defined the function that will invoke the required callback in action.js, note that callback must be func reference hence define it as a higher-order func if necessary in action.js
-    TO REMOVE SHORCUTS:
+    TO REMOVE SHORTCUTS:
         #1. Remove the option from defaultKeys.json
         #2. Remove the case from addShortcut.js
     RESTRICTION:

--- a/v1/src/simulator/src/hotkey_binder/documentation.txt
+++ b/v1/src/simulator/src/hotkey_binder/documentation.txt
@@ -29,13 +29,13 @@ MAIN FILEs:
     * Others
 
 USAGE:
-    TO ADD SHORCUTS:
+    TO ADD SHORTCUTS:
         #1 add the shortcut in the defaultKeys.json file
-        #2 Assign the callback in addShorcut.js:
+        #2 Assign the callback in addShortcut.js:
             * the callback should be a func reference,if function to be invoked is already defined in the codebase just set it as it is. (for some func reference may not work, refer next step)
 
             *for callback not present in the codebase, or is present but doesn't work as intended, defined the function that will invoke the required callback in action.js, note that callback must be func reference hence define it as a higher-order func if necessary in action.js
-    TO REMOVE SHORCUTS:
+    TO REMOVE SHORTCUTS:
         #1. Remove the option from defaultKeys.json
         #2. Remove the case from addShortcut.js
     RESTRICTION:


### PR DESCRIPTION
Fixes #956

Updated shortcut spelling in both hotkey binder documentation files: src/simulator/src/hotkey_binder/documentation.txt and v1/src/simulator/src/hotkey_binder/documentation.txt.

Replaced SHORCUTS with SHORTCUTS and addShorcut.js with addShortcut.js.

How to verify: open both files and confirm the corrected terms.