### PR TITLE
docs: fix preferred typo in hotkey panel comment

### DIFF
--- a/v1/src/simulator/src/hotkey_binder/view/panel.ui.js
+++ b/v1/src/simulator/src/hotkey_binder/view/panel.ui.js
@@ -2,7 +2,7 @@ import { setUserKeys } from '../model/actions'
 
 /**
  * fn to update the htokey panel UI with the currently set configuration
- * @param {string} mode user prefered if present, or default keys configuration
+ * @param {string} mode user preferred if present, or default keys configuration
  */
 export const updateHTML = (mode) => {
     let x = 0


### PR DESCRIPTION
Fixes #958

Updated the JSDoc mode parameter description in v1/src/simulator/src/hotkey_binder/view/panel.ui.js by changing prefered to preferred.

This is a comment-only cleanup for readability.

How to verify: open the file and confirm the parameter comment uses preferred.