### PR TITLE
docs: fix transparent typo in save function comments

### DIFF
--- a/src/simulator/src/data/save.js
+++ b/src/simulator/src/data/save.js
@@ -165,7 +165,7 @@ function download(filename, text) {
  * Function to generate image for the circuit
  * @param {string} imgType - ex: png,jpg etc.
  * @param {string} view - view type ex: full
- * @param {boolean} transparent - tranparent bg or not
+ * @param {boolean} transparent - transparent bg or not
  * @param {number} resolution - resolution of the image
  * @param {boolean=} down - will download if true
  * @category data

--- a/v1/src/simulator/src/data/save.js
+++ b/v1/src/simulator/src/data/save.js
@@ -166,7 +166,7 @@ function download(filename, text) {
  * Function to generate image for the circuit
  * @param {string} imgType - ex: png,jpg etc.
  * @param {string} view - view type ex: full
- * @param {boolean} transparent - tranparent bg or not
+ * @param {boolean} transparent - transparent bg or not
  * @param {number} resolution - resolution of the image
  * @param {boolean=} down - will download if true
  * @category data


### PR DESCRIPTION
## Summary
- fix the JSDoc typo tranparent -> transparent in the simulator save helper comment
- apply the same correction in both src and v1 codepaths to keep docs in sync

## Issue
Ref #962

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typographical error in internal documentation comments.

---

**Note:** This release contains minimal user-facing changes, consisting primarily of internal documentation improvements with no impact on functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->