### PR TITLE
refactor: introduce shared apiClient wrapper (no migrations yet)

### DIFF
--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -1,0 +1,103 @@
+// Incremental shared fetch wrapper; call sites can migrate here gradually.
+
+export type UnauthorizedHandler = (
+  response: Response
+) => void | Promise<void>;
+
+export interface ApiFetchOptions extends RequestInit {
+  onUnauthorized?: UnauthorizedHandler;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+export function getCookie(name: string): string | null {
+  if (typeof document === "undefined" || !document.cookie) {
+    return null;
+  }
+
+  const cookieParts = document.cookie.split(";");
+
+  for (const part of cookieParts) {
+    const trimmedPart = part.trim();
+    if (!trimmedPart) {
+      continue;
+    }
+
+    const separatorIndex = trimmedPart.indexOf("=");
+    const rawName =
+      separatorIndex >= 0
+        ? trimmedPart.slice(0, separatorIndex)
+        : trimmedPart;
+    const rawValue =
+      separatorIndex >= 0 ? trimmedPart.slice(separatorIndex + 1) : "";
+
+    let decodedName = rawName;
+    try {
+      decodedName = decodeURIComponent(rawName);
+    } catch {
+      // Keep raw value when decoding fails.
+    }
+
+    if (decodedName !== name) {
+      continue;
+    }
+
+    try {
+      return decodeURIComponent(rawValue);
+    } catch {
+      return rawValue;
+    }
+  }
+
+  return null;
+}
+
+export function getAuthToken(): string | null {
+  return getCookie("cvt");
+}
+
+export async function apiFetch(
+  url: string | URL,
+  options: ApiFetchOptions = {}
+): Promise<Response> {
+  const { onUnauthorized, headers: callerHeaders, body: callerBody, ...rest } =
+    options;
+  const headers = new Headers(callerHeaders);
+
+  if (!headers.has("Accept")) {
+    headers.set("Accept", "application/json");
+  }
+
+  const token = getAuthToken();
+  if (token && !headers.has("Authorization")) {
+    headers.set("Authorization", `Token ${token}`);
+  }
+
+  let requestBody: BodyInit | null | undefined = callerBody;
+  if (isPlainObject(callerBody)) {
+    requestBody = JSON.stringify(callerBody);
+    if (!headers.has("Content-Type")) {
+      headers.set("Content-Type", "application/json");
+    }
+  }
+
+  const requestOptions: RequestInit = { ...rest, headers };
+  if (requestBody !== undefined) {
+    requestOptions.body = requestBody;
+  }
+
+  const response = await fetch(url, requestOptions);
+
+  if (response.status === 401 && onUnauthorized) {
+    await onUnauthorized(response);
+  }
+
+  return response;
+}

--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -17,6 +17,19 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return prototype === Object.prototype || prototype === null;
 }
 
+function isSameOrigin(target: string | URL): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  try {
+    const resolved = new URL(target.toString(), window.location.href);
+    return resolved.origin === window.location.origin;
+  } catch {
+    return false;
+  }
+}
+
 export function getCookie(name: string): string | null {
   if (typeof document === "undefined" || !document.cookie) {
     return null;
@@ -64,24 +77,27 @@ export function getAuthToken(): string | null {
 }
 
 export async function apiFetch(
+  // Keep string | URL for this incremental wrapper; can widen later if needed.
   url: string | URL,
   options: ApiFetchOptions = {}
 ): Promise<Response> {
   const { onUnauthorized, headers: callerHeaders, body: callerBody, ...rest } =
     options;
   const headers = new Headers(callerHeaders);
+  const method = (rest.method ?? "GET").toUpperCase();
+  const shouldAttachBody = method !== "GET" && method !== "HEAD";
 
   if (!headers.has("Accept")) {
     headers.set("Accept", "application/json");
   }
 
   const token = getAuthToken();
-  if (token && !headers.has("Authorization")) {
+  if (token && isSameOrigin(url) && !headers.has("Authorization")) {
     headers.set("Authorization", `Token ${token}`);
   }
 
   let requestBody: BodyInit | null | undefined = callerBody;
-  if (isPlainObject(callerBody)) {
+  if (shouldAttachBody && isPlainObject(callerBody)) {
     requestBody = JSON.stringify(callerBody);
     if (!headers.has("Content-Type")) {
       headers.set("Content-Type", "application/json");
@@ -89,14 +105,14 @@ export async function apiFetch(
   }
 
   const requestOptions: RequestInit = { ...rest, headers };
-  if (requestBody !== undefined) {
+  if (shouldAttachBody && requestBody !== undefined) {
     requestOptions.body = requestBody;
   }
 
   const response = await fetch(url, requestOptions);
 
   if (response.status === 401 && onUnauthorized) {
-    await onUnauthorized(response);
+    await onUnauthorized(response.clone());
   }
 
   return response;


### PR DESCRIPTION
## Fixes #994 

<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

This PR introduces a small shared module: `src/services/apiClient.ts`.

### Problem
API calls across the codebase currently use direct `fetch(...)` calls, leading to:
- Repeated Authorization header construction
- Inconsistent `401` handling
- Token extraction logic living inside a page component
- Scattered header normalization logic

This makes session-related improvements harder to implement consistently.

### Solution
I introduced a centralized `apiFetch(...)` wrapper that:

- Safely merges caller headers
- Ensures `Accept: application/json` if not already present
- Attaches `Authorization: Token <cvt>` if a cookie token exists
- Automatically stringifies plain object bodies (without affecting FormData, Blob, etc.)
- Returns the raw `Response` (no automatic JSON parsing)
- Supports an optional `onUnauthorized` callback for 401 handling

### Why this implementation?
This approach is incremental and non-breaking:

- No existing files were modified
- No behavior change has been introduced yet
- Migration will happen gradually in follow-up PRs
- It creates a clean boundary for future Rails session integration and consistent 401 handling

The implementation uses:
- Prototype-based detection for plain objects (to avoid incorrectly stringifying FormData or other body types)
- `Headers` API for safe case-insensitive header handling
- A minimal, framework-agnostic design so both Vue SFCs and simulator JS modules can consume it

This PR is purely structural and prepares the codebase for more consistent API handling in future changes.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized API request handling with automatic JSON serialization and header normalization
  * Automatic injection of stored authentication token for same-origin requests
  * Configurable handling of unauthorized responses (e.g., automatic callbacks on 401)
  * More consistent and reliable API behavior across the application
<!-- end of auto-generated comment: release notes by coderabbit.ai -->