### PR TITLE
Feat: add preview in export dialog + fix clipboard

### DIFF
--- a/src/components/DialogBox/ExportProject.vue
+++ b/src/components/DialogBox/ExportProject.vue
@@ -10,9 +10,7 @@
                     size="x-small"
                     icon
                     class="dialogClose"
-                    @click="
-                        SimulatorState.dialogBox.export_project_dialog = false
-                    "
+                    @click="closeDialog"
                 >
                     <v-icon>mdi-close</v-icon>
                 </v-btn>
@@ -28,9 +26,70 @@
                     />
                     <p>.cv</p>
                 </div>
+
+                <!-- Preview Section -->
+                <div
+                    v-if="showPreview"
+                    id="export-project-preview-div"
+                    title="Export Preview"
+                >
+                    <div v-if="isLoading" class="previewLoading">
+                        <v-progress-circular
+                            indeterminate
+                            size="24"
+                            width="2"
+                            color="white"
+                        />
+                        <span>Generating preview...</span>
+                    </div>
+                    <div v-else-if="previewError" class="previewError">
+                        <v-icon color="red" size="small"
+                            >mdi-alert-circle</v-icon
+                        >
+                        <span>{{ previewError }}</span>
+                    </div>
+                    <Codemirror
+                        v-else-if="previewData"
+                        id="export-project-code-window"
+                        :value="previewData"
+                        :options="cmOptions"
+                        border
+                        :height="300"
+                        :width="700"
+                    />
+                    <div v-else class="previewError">
+                        <v-icon color="orange" size="small"
+                            >mdi-information</v-icon
+                        >
+                        <span>No preview data available.</span>
+                    </div>
+                </div>
             </v-card-text>
             <v-card-actions>
-                <v-btn class="messageBtn" @click="exportAsFile"> Save </v-btn>
+                <v-btn
+                    class="messageBtn"
+                    block
+                    :disabled="isLoading"
+                    @click="previewProject"
+                >
+                    {{ showPreview ? 'Refresh Preview' : 'Preview' }}
+                </v-btn>
+                <v-btn
+                    class="messageBtn"
+                    block
+                    :disabled="isLoading"
+                    @click="exportAsFile"
+                >
+                    Save
+                </v-btn>
+                <v-btn
+                    class="messageBtn"
+                    block
+                    :disabled="isLoading"
+                    @click="copyClipboard()"
+                >
+                    Copy to Clipboard
+                </v-btn>
             </v-card-actions>
         </v-card>
     </v-dialog>
@@ -41,7 +100,7 @@ import { ref } from 'vue'
 import { useState } from '#/store/SimulatorStore/state'
 import { useProjectStore } from '#/store/projectStore'
 import { generateSaveData } from '#/simulator/src/data/save'
-import { downloadFile } from '#/simulator/src/utils'
+import { downloadFile, copyToClipboard, showMessage } from '#/simulator/src/utils'
 import { escapeHtml } from '#/simulator/src/utils'
 
 export function ExportProject() {
@@ -57,31 +116,122 @@ export function ExportProject() {
 </script>
 
 <script lang="ts" setup>
+import Codemirror from 'codemirror-editor-vue3'
+
+import 'codemirror/mode/javascript/javascript.js'
+
+import 'codemirror/theme/dracula.css'
+
 const SimulatorState = useState()
 const projectStore = useProjectStore()
 
-const fileNameInput = ref(
-    projectStore.getProjectName +
-        '__' +
-        new Date().toLocaleString().replace(/[: \/,-]/g, '_')
-)
+const fileNameInput = ref(projectStore.getProjectName || 'untitled')
 
-const exportAsFile = async () => {
-    let fileName = escapeHtml(fileNameInput.value) || 'untitled'
-    const circuitData = await generateSaveData(
-        projectStore.getProjectName,
-        false
-    )
-    fileName = `${fileName.replace(/[^a-z0-9]/gi, '_')}.cv`
-    downloadFile(fileName, circuitData)
+
+const showPreview = ref(false)
+const previewData = ref('')
+const previewError = ref('')
+const isLoading = ref(false)
+
+const cmOptions = ref({
+    mode: 'application/json',
+    autoRefresh: true,
+    styleActiveLine: true,
+    lineNumbers: true,
+    readOnly: true,
+    autoCloseBrackets: true,
+    smartIndent: true,
+    indentWithTabs: true,
+})
+
+function closeDialog() {
+    showPreview.value = false
+    previewData.value = ''
+    previewError.value = ''
+    isLoading.value = false
     SimulatorState.dialogBox.export_project_dialog = false
+}
+
+async function generateCircuitDataString(): Promise<string | null> {
+    try {
+        const data = await generateSaveData(
+            projectStore.getProjectName,
+            false
+        )
+        if (data instanceof Error) {
+            return null
+        }
+        if (
+            !data ||
+            (typeof data === 'object' && Object.keys(data).length === 0)
+        ) {
+            return null
+        }
+        return JSON.stringify(data, null, 2)
+    } catch (err) {
+        console.error('Failed to generate circuit data:', err)
+        return null
+    }
+}
+
+async function previewProject() {
+    isLoading.value = true
+    previewError.value = ''
+    showPreview.value = true
+
+    const dataStr = await generateCircuitDataString()
+
+    if (dataStr === null) {
+        previewError.value =
+            'Failed to generate preview. The circuit may be empty or the operation was cancelled.'
+        isLoading.value = false
+        return
+    }
+
+    previewData.value = dataStr
+    isLoading.value = false
+}
+
+async function exportAsFile() {
+    isLoading.value = true
+    let fileName = escapeHtml(fileNameInput.value) || 'untitled'
+
+    const dataStr = previewData.value || (await generateCircuitDataString())
+
+    if (!dataStr) {
+        showMessage('Export failed – could not generate circuit data.')
+        isLoading.value = false
+        return
+    }
+
+    fileName = `${fileName.replace(/[^a-z0-9]/gi, '_')}.cv`
+    downloadFile(fileName, dataStr)
+    closeDialog()
+}
+
+
+async function copyClipboard() {
+    isLoading.value = true
+
+    const dataStr = previewData.value || (await generateCircuitDataString())
+
+    if (!dataStr) {
+        showMessage('Copy failed – could not generate circuit data.')
+        isLoading.value = false
+        return
+    }
+
+    await copyToClipboard(dataStr)
+    showMessage('Circuit data copied to clipboard')
+    closeDialog()
 }
 </script>
 
 <style scoped>
 .exportProjectCard {
     height: auto;
-    width: 30rem;
+    width: auto;
+    max-width: 48rem;
     justify-content: center;
     margin: auto;
     backdrop-filter: blur(5px);
@@ -111,6 +261,30 @@ const exportAsFile = async () => {
 
 .fileNameInput input {
     text-align: center;
+}
+
+/* ── Preview Section ── */
+#export-project-preview-div {
+    margin-top: 1rem;
+}
+
+.previewLoading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 1.5rem;
+    font-size: 0.85rem;
+    color: #aaa;
+}
+
+.previewError {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.75rem;
+    font-size: 0.82rem;
+    color: #ff6b6b;
 }
 </style>
 

--- a/src/components/DialogBox/ExportProject.vue
+++ b/src/components/DialogBox/ExportProject.vue
@@ -205,7 +205,14 @@ async function exportAsFile() {
     }
 
     fileName = `${fileName.replace(/[^a-z0-9]/gi, '_')}.cv`
-    downloadFile(fileName, dataStr)
+    try {
+        await downloadFile(fileName, dataStr)
+    } catch (err) {
+        console.error('Export failed:', err)
+        showMessage('Export failed – could not save the file.')
+        isLoading.value = false
+        return
+    }
     closeDialog()
 }
 
@@ -221,8 +228,12 @@ async function copyClipboard() {
         return
     }
 
-    await copyToClipboard(dataStr)
-    showMessage('Circuit data copied to clipboard')
+    const success = await copyToClipboard(dataStr)
+    if (success) {
+        showMessage('Circuit data copied to clipboard')
+    } else {
+        showMessage('Failed to copy circuit data to clipboard.')
+    }
     closeDialog()
 }
 </script>

--- a/src/simulator/src/utils.ts
+++ b/src/simulator/src/utils.ts
@@ -160,7 +160,18 @@ export function openInNewTab(url: string | URL | undefined) {
   win?.focus();
 }
 
-export function copyToClipboard(text: string) {
+export async function copyToClipboard(text: string): Promise<boolean> {
+  // Modern Clipboard API — works reliably inside dialogs & focus-traps
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Fall through to legacy method
+    }
+  }
+
+  // Legacy fallback using execCommand for older browsers
   const textarea = document.createElement("textarea");
 
   // Move it off-screen.


### PR DESCRIPTION
Fixes #1005

#### Describe the changes you have made in this PR -

**Commit 1 — Feature: JSON Preview in Export Dialog** (`src/components/DialogBox/ExportProject.vue`)
- Added a **Preview** button using the same `Codemirror` editor component as `ExportVerilog` (same dimensions, border, height/width pattern)
- Circuit data is now stringified via `JSON.stringify()` before passing to `downloadFile`/`copyToClipboard` — previously the raw JS object was passed, resulting in `[object Object]` in saved files and clipboard
- Added loading spinner (`v-progress-circular`), error state, and empty-data guard (`v-else-if="previewData"`) for the preview panel
- Cached preview data is reused for Save/Copy when already generated (avoids redundant `generateSaveData` calls)
- Default filename simplified to project name only (matches original repo's SaveAs.js behavior)
- Button order: **Preview → Save → Copy to Clipboard**

**Commit 2 — Fix: Clipboard utility** (`src/simulator/src/utils.ts`)
- `copyToClipboard` now uses `navigator.clipboard.writeText()` as the primary path, with legacy `document.execCommand("copy")` as fallback
- Made the function `async` to support `await` on the modern Clipboard API
- Discovered while testing: Vuetify's `v-dialog` focus-trap can cause `execCommand` to silently fail in the standalone Vite dev server. The modern API is unaffected. This does not impact production (CircuitVerse.org).

### Screenshots of the UI changes (If any) -
<!-- Add screenshots of the export dialog with the Preview button here -->


https://github.com/user-attachments/assets/74bbd1f7-824a-4088-88c1-8c771e03ecdf


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**Explain your implementation approach:**

**Approach:** I followed the existing `ExportVerilog.vue` pattern — same `Codemirror` component (`codemirror-editor-vue3`), same `height: 300` / `width: 700`, same `messageBtn block` button layout. This keeps the UI consistent across export dialogs.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Preview section with syntax-highlighted code display in the export dialog, plus loading and error states.
  * Added Preview/Refresh, Save, and Copy to Clipboard action buttons; export filename now defaults to the project name.
* **Improved Reliability**
  * Clipboard copy now uses a more robust, cross-browser approach for better success rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->