### PR TITLE
Resolve v1 drag-and-drop functionality by fixing module initialization

### DIFF
--- a/src/styles/tutorials.scss
+++ b/src/styles/tutorials.scss
@@ -1,4 +1,4 @@
-@import '/node_modules/driver.js/dist/driver.min.css';
+@import '../../node_modules/driver.js/dist/driver.min.css';
 
 #driver-highlighted-element-stage {
     background-color: transparent !important;

--- a/v1/src/styles/tutorials.scss
+++ b/v1/src/styles/tutorials.scss
@@ -1,4 +1,4 @@
-@import '/node_modules/driver.js/dist/driver.min.css';
+@import '../../../node_modules/driver.js/dist/driver.min.css';
 
 #driver-highlighted-element-stage {
     background-color: transparent !important;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -53,9 +53,9 @@ export default defineConfig(() => {
     },
     server: {
       port: 4000,
-    },
-    fs: {
-      allow: [".."],
+      fs: {
+        allow: [".."],
+      },
     },
     preview: {
       port: 4173,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -55,8 +55,8 @@ export default defineConfig(() => {
       port: 4000,
     },
     fs: {
-          allow: ['..']
-      },
+      allow: [".."],
+    },
     preview: {
       port: 4173,
     },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig(() => {
   const isDesktop = !!process.env.DESKTOP_MODE;
 
   return {
+    root: `./${version}`,
     plugins: [
       vue(),
       vuetify({ autoImport: true }),
@@ -36,7 +37,7 @@ export default defineConfig(() => {
     },
     base: process.env.VITE_BASE || (isDesktop ? "/" : `/simulatorvue/${version}/`),
     build: {
-      outDir: `./dist/simulatorvue/${version}/`,
+      outDir: `../dist/simulatorvue/${version}/`,
       assetsDir: "assets",
       chunkSizeWarningLimit: 1600,
       rollupOptions: {
@@ -53,6 +54,9 @@ export default defineConfig(() => {
     server: {
       port: 4000,
     },
+    fs: {
+          allow: ['..']
+      },
     preview: {
       port: 4173,
     },


### PR DESCRIPTION

Fixes #922 

<!-- Add issue number above --> 

#### Describe the changes you have made in this PR
This PR fixes the drag-and-drop functionality in v1 that was broken due to incorrect module loading. The root cause was that v0's main.ts file was being loaded instead of v1's main.ts, which meant the circuit element modules were never properly initialized before components tried to use them.
<img width="1500" height="311" alt="image" src="https://github.com/user-attachments/assets/cd22385d-23a0-45b0-bbb0-29b0586f6885" />


**Changes made:**
- Set Vite root to version-specific directory to ensure correct file loading
- Update CSS import path in tutorials.scss to work with new root
- Add filesystem access permission for parent directory in dev server
- This fixes the issue where v0's files were loading instead of v1's files
- Resolves drag-and-drop elements not working in v1 due to uninitialized modules

### Screenshots of the UI changes (If any)
Before: Drag-and-drop not working, console errors when hovering/clicking circuit elements
<img width="1500" height="311" alt="image" src="https://github.com/user-attachments/assets/4b5a06dc-3edb-46ee-bec2-f934e6284c38" />

After: Drag-and-drop working correctly
<img width="1528" height="351" alt="image" src="https://github.com/user-attachments/assets/1558c2c8-a260-40af-b2e6-57abff404efe" />


<!-- Do not add code diff here -->

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

**Problem:** When running v1 of the simulator, the drag-and-drop functionality for circuit elements was completely broken. The browser console showed errors like "modules[elementName] is not a constructor" and "Cannot read properties of undefined (reading 'prototype')".

**Root Cause Analysis:** Through debugging, I discovered that v0's main.ts file was being loaded instead of v1's main.ts (confirmed via import.meta.url showing `/simulatorvue/v1/v0/src/main.ts`). This happened because Vite was resolving file paths from the project root, causing the path aliases (#/ and @/) to incorrectly point to v0's source files even when VITE_SIM_VERSION was set to "v1".

**Testing:**
- Verified v1 loads correctly and drag-and-drop works
- Confirmed v0 still works as expected
- Tested that modules are properly initialized before components mount
- Checked build output paths are correct

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated stylesheet import to use a relative path to node modules, ensuring consistent asset resolution.
  * Adjusted project root and build output directory settings and expanded development server file access to accommodate the revised layout and build outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->