### PR TITLE
Fix: Remove extra popup when creating new project

### DIFF
--- a/src/simulator/src/data/project.ts
+++ b/src/simulator/src/data/project.ts
@@ -182,8 +182,8 @@ window.onbeforeunload = async function () {
 /**
  * Function to clear project
  */
-export async function clearProject() {
-  if (await confirmOption("Would you like to clear the project?")) {
+export async function clearProject(verify: boolean = true) {
+  if (!verify || await confirmOption("Would you like to clear the project?")) {
     globalScope = undefined;
     resetScopeList();
     // $('.circuits').remove()
@@ -202,7 +202,7 @@ export async function newProject(verify: boolean) {
     !checkToSave() ||
     (await confirmOption("What you like to start a new project? Any unsaved changes will be lost."))
   ) {
-    clearProject();
+    clearProject(false);
     localStorage.removeItem("recover");
     const baseUrl =
       window.location.origin !== "null" ? window.location.origin : "http://localhost:4000";


### PR DESCRIPTION
## PR Description

### Title
Fix: Remove extra confirmation dialog when creating new project

### Linked issue
Fixes #399

### What changed
- in `src/simulator/src/data/project.ts`:
  - `clearProject()` now accepts an optional `verify` flag (default true)
  - if `verify=false`, `clearProject` clears state directly without extra confirm dialog
  - `newProject()` now calls `clearProject(false)` after user confirms unsaved-changes warning
- This removes duplicate `clear project` confirmation when the user already confirmed they want to start a new project and lose unsaved work.

### Screenshots
- UI is unchanged except fewer sequential dialogs.  
- No screenshot attached; behavior is:
  1. create unsaved changes
  2. click “New project”
  3. confirm “Any unsaved changes will be lost”
  4. directly change project state without second popup

---

## Code Understanding and AI Usage

**Did you use AI assistance?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance

**AI-assistance details:** N/A

**Implementation approach**
- Problem: `newProject()` did a confirmation, then called `clearProject()` which also confirmed.
- Alternative considered: “skip double confirm by passing a parameter to `clearProject`”.
- Chosen: simple flag-based guard in `clearProject` retaining the same default behavior for other calls.
- Key functions:
  - `clearProject(verify: boolean = true)`
  - `newProject(verify: boolean)`
- Edge case: calls from other code that rely on confirm still work because default is true.
- No watermelons.

---

## Checklist before review
- [x] PR title and issue link added
- [x] Self-review done
- [x] I can explain every function/logic block I added
- [x] Tested manually through flow
- [x] Considered edge cases
- [ ] Added automated tests (not necessary for a very small behavior fix but could be added)
- [x] Code follows style conventions

---

> Note: In GitHub PR description, check **Allow edits from maintainers** if you'd like maintainers to refine this further.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated a redundant confirmation dialog when creating a new project, providing a more streamlined workflow and reducing friction in the project setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->