### PR TITLE
fix: add missing :key attributes on v-for loops

### DIFF
--- a/src/components/Extra.vue
+++ b/src/components/Extra.vue
@@ -36,8 +36,8 @@
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Message Display -->
     <div id="MessageDiv">
-  <div v-for="(mes) in useState().successMessages" :key="'success-' + mes">{{ mes }}</div>
-  <div v-for="(error) in useState().errorMessages" :key="'error-' + error">{{ error }}</div>
+  <div v-for="(mes, index) in useState().successMessages" :key="'success-' + index + '-' + mes" class="alert alert-success" role="alert">{{ mes }}</div>
+<div v-for="(error, index) in useState().errorMessages" :key="'error-' + index + '-' + error" class="alert alert-danger" role="alert">{{ error }}</div>
 </div>
     <!-- --------------------------------------------------------------------------------------------- -->
 

--- a/src/components/Extra.vue
+++ b/src/components/Extra.vue
@@ -35,10 +35,11 @@
 
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Message Display -->
-    <div id="MessageDiv">
-        <div v-for="mes in useState().successMessages" class='alert alert-success' role='alert'> {{ mes }}</div>
-        <div v-for="error in useState().errorMessages" class='alert alert-danger' role='alert'> {{ error }}</div>
-    </div>
+<div id="MessageDiv">
+  <div v-for="(mes, index) in useState().successMessages" :key="'success-' + index">{{ mes }}</div>
+  <div v-for="(error, index) in useState().errorMessages" :key="'error-' + index">{{ error }}</div>
+
+</div>
     <!-- --------------------------------------------------------------------------------------------- -->
 
     <!-- --------------------------------------------------------------------------------------------- -->

--- a/src/components/Extra.vue
+++ b/src/components/Extra.vue
@@ -35,10 +35,9 @@
 
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Message Display -->
-<div id="MessageDiv">
-  <div v-for="(mes, index) in useState().successMessages" :key="'success-' + index">{{ mes }}</div>
-  <div v-for="(error, index) in useState().errorMessages" :key="'error-' + index">{{ error }}</div>
-
+    <div id="MessageDiv">
+  <div v-for="(mes) in useState().successMessages" :key="'success-' + mes">{{ mes }}</div>
+  <div v-for="(error) in useState().errorMessages" :key="'error-' + error">{{ error }}</div>
 </div>
     <!-- --------------------------------------------------------------------------------------------- -->
 

--- a/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink2.vue
+++ b/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink2.vue
@@ -22,7 +22,7 @@
               <v-list-item
                   class="menuListItem"
                   v-for="(listItem, index) in navbarItem.dropdownItems"
-                  :key="index"
+                  :key="listItem.itemid ?? index"
                   density="compact"
                   :id="listItem.itemid"
                   @click.stop="logixFunction[listItem.itemid]()"

--- a/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink2.vue
+++ b/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink2.vue
@@ -22,10 +22,10 @@
               <v-list-item
                   class="menuListItem"
                   v-for="(listItem, index) in navbarItem.dropdownItems"
-                  :key="listItem.itemid ?? index"
+                  :key="listItem.itemid || `item-${index}`"
                   density="compact"
                   :id="listItem.itemid"
-                  @click.stop="logixFunction[listItem.itemid]()"
+                  `@click.stop`="logixFunction[listItem.itemid]()"
                   v-bind="
                   Object.fromEntries(
                       listItem.attributes.map((attr:AttrType) => [

--- a/v1/src/components/Extra.vue
+++ b/v1/src/components/Extra.vue
@@ -35,10 +35,10 @@
 
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Message Display -->
-<div id="MessageDiv">
-<div v-for="(mes) in useState().successMessages" :key="'success-' + mes">{{ mes }}</div>
-  <div v-for="(error) in useState().errorMessages" :key="'error-' + error">{{ error }}</div>
-</div>
+    <div id="MessageDiv">
+        <div v-for="mes in useState().successMessages" class='alert alert-success' role='alert'> {{ mes }}</div>
+        <div v-for="error in useState().errorMessages" class='alert alert-danger' role='alert'> {{ error }}</div>
+    </div>
     <!-- --------------------------------------------------------------------------------------------- -->
 
     <!-- --------------------------------------------------------------------------------------------- -->

--- a/v1/src/components/Extra.vue
+++ b/v1/src/components/Extra.vue
@@ -35,10 +35,10 @@
 
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Message Display -->
-    <div id="MessageDiv">
-        <div v-for="mes in useState().successMessages" class='alert alert-success' role='alert'> {{ mes }}</div>
-        <div v-for="error in useState().errorMessages" class='alert alert-danger' role='alert'> {{ error }}</div>
-    </div>
+<div id="MessageDiv">
+    <div v-for="(mes, index) in useState().successMessages" :key="index" class='alert alert-success' role='alert'> {{ mes }}</div>
+    <div v-for="(error, index) in useState().errorMessages" :key="index" class='alert alert-danger' role='alert'> {{ error }}</div>
+</div>
     <!-- --------------------------------------------------------------------------------------------- -->
 
     <!-- --------------------------------------------------------------------------------------------- -->

--- a/v1/src/components/Extra.vue
+++ b/v1/src/components/Extra.vue
@@ -36,8 +36,8 @@
     <!-- --------------------------------------------------------------------------------------------- -->
     <!-- Message Display -->
 <div id="MessageDiv">
-    <div v-for="(mes, index) in useState().successMessages" :key="index" class='alert alert-success' role='alert'> {{ mes }}</div>
-    <div v-for="(error, index) in useState().errorMessages" :key="index" class='alert alert-danger' role='alert'> {{ error }}</div>
+<div v-for="(mes) in useState().successMessages" :key="'success-' + mes">{{ mes }}</div>
+  <div v-for="(error) in useState().errorMessages" :key="'error-' + error">{{ error }}</div>
 </div>
     <!-- --------------------------------------------------------------------------------------------- -->
 

--- a/v1/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink2.vue
+++ b/v1/src/components/Navbar/NavbarLinks/NavbarLink/NavbarLink2.vue
@@ -22,7 +22,7 @@
               <v-list-item
                   class="menuListItem"
                   v-for="(listItem, index) in navbarItem.dropdownItems"
-                  :key="index"
+                  :key="listItem.itemid ?? index"
                   density="compact"
                   :id="listItem.itemid"
                   @click.stop="logixFunction[listItem.itemid]()"


### PR DESCRIPTION
Fixes #1012

## Changes Made
- Added :key="index" to v-for loops in MessageDiv
- Resolves rendering issues caused by missing key attributes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification rendering so success and error alerts display consistently and remain stable during updates.
  * Increased navigation dropdown stability by using more reliable item identification to prevent visual glitches and improve responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->