### PR TITLE
fix: remove extra confirmation popup when creating new project

### DIFF
--- a/src/simulator/src/data/project.ts
+++ b/src/simulator/src/data/project.ts
@@ -200,9 +200,13 @@ export async function newProject(verify: boolean) {
     verify ||
     projectSaved ||
     !checkToSave() ||
-    (await confirmOption("What you like to start a new project? Any unsaved changes will be lost."))
+    (await confirmOption("Would you like to start a new project? Any unsaved changes will be lost."))
   ) {
-    clearProject();
+    // Directly reset project state without calling clearProject(), which
+    // would show a second confirmation dialog (fixes #399).
+    globalScope = undefined;
+    resetScopeList();
+    newCircuit("main");
     localStorage.removeItem("recover");
     const baseUrl =
       window.location.origin !== "null" ? window.location.origin : "http://localhost:4000";


### PR DESCRIPTION
## Summary

Fixes #399

When clicking Project -> New Project, users saw two confirmation dialogs stacked one after the other:
1. "Would you like to start a new project?" (from `newProject()`)
2. 2. "Would you like to clear the project?" (from `clearProject()`, which `newProject()` was calling)
The second popup was completely unnecessary since the user already confirmed they want a new project.

## Root Cause

`newProject()` was calling `clearProject()` to reset state, but `clearProject()` shows its own confirm dialog:

```typescript
// clearProject() - always shows its own confirmation
export async function clearProject() {
  if (await confirmOption("Would you like to clear the project?")) {
    // ...resets state
  }
}
```

## Fix

`newProject()` now directly resets the project state inline (same logic as inside `clearProject()`) without triggering a second dialog:

```typescript
// Now resets state directly, no second dialog
globalScope = undefined;
resetScopeList();
newCircuit("main");
```

Closes #399

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the wording of the new project confirmation dialog to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->