### PR TITLE
fix: prevent RangeError crash in dec2bin when value overflows bitWidth

### DIFF
--- a/src/simulator/src/node.js
+++ b/src/simulator/src/node.js
@@ -72,10 +72,17 @@ export function bin2dec(binString) {
     return parseInt(binString, 2)
 }
 
+/**
+ * Utility function to convert decimal to binary string with optional padding/truncation to bitWidth.
+ * @param {number} dec - decimal number to be converted
+ * @param {number=} bitWidth - optional target bit width
+ * @category node
+ */
 export function dec2bin(dec, bitWidth = undefined) {
     // only for positive nos
     var bin = dec.toString(2)
     if (bitWidth == undefined) return bin
+    if (bin.length > bitWidth) return bin.slice(-bitWidth)
     return '0'.repeat(bitWidth - bin.length) + bin
 }
 

--- a/src/simulator/src/testbench.ts
+++ b/src/simulator/src/testbench.ts
@@ -329,13 +329,17 @@ function tickClock(scope: any) {
   play(scope);
 }
 
-// Do we have any other function to do this?
-// Utility function. Converts decimal number to binary string
+/**
+ * Utility function to convert decimal to binary string with optional padding/truncation to bitWidth.
+ * @param {number|undefined} dec - decimal number to convert
+ * @param {number=} bitWidth - optional target bit width
+ */
 function dec2bin(dec: number | undefined, bitWidth = undefined) {
   if (dec === undefined) return "X";
   const bin = (dec >>> 0).toString(2);
   if (!bitWidth) return bin;
 
+  if (bin.length > bitWidth) return bin.slice(-bitWidth);
   return "0".repeat(bitWidth - bin.length) + bin;
 }
 


### PR DESCRIPTION
While working with the simulator I noticed that connecting an Input element set to a value higher than its bitWidth would silently break canvas rendering — the element would just stop displaying correctly with no visible error. Traced it down to dec2bin() in node.js.
The function converts a decimal state value to a binary string for display, then left-pads it with zeros to match the target bitWidth. The issue is it never checks whether the binary string is already longer than bitWidth before calculating the padding. When it is longer, bitWidth - bin.length goes negative, and '0'.repeat(-1) throws an uncaught RangeError.
Concrete example — an Input element with bitWidth = 3 holding value 15:

(15).toString(2) → "1111" (length 4)
'0'.repeat(3 - 4) → '0'.repeat(-1) → RangeError: Invalid count value: -1

This crash happens mid-draw since Output.js and Input.js call dec2bin(this.state, this.bitWidth) directly during canvas rendering. The same function also exists in testbench.ts for formatting testbench output rows, so applied the same fix there too.
Added a bounds check — if the binary string is already longer than bitWidth, slice the last bitWidth digits and return early. Keeping the least significant bits matches how real hardware handles overflow, the high bits get dropped.
Screenshots: None — logic only fix, no UI changes.
PR Category

- [x] Bug Fix

Checklist

- [x] Performed a self-review of my code
- [x] Tested edge cases — value of 0, exact bitWidth match, and overflow
- [x] Follows project style guidelines
