### PR TITLE
feat: wrap synthesizeVerilog() with 30s timeout guard

### DIFF
--- a/v1/src/simulator/spec/clientSynthesis.spec.js
+++ b/v1/src/simulator/spec/clientSynthesis.spec.js
@@ -1,0 +1,186 @@
+// Tests for the synthesis timeout guard in clientSynthesis.js.
+
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+class MockWorker {
+    constructor() {
+        this._listeners = { message: [], error: [] }
+        this.postMessage = vi.fn()
+        this.terminate = vi.fn()
+    }
+
+    addEventListener(type, fn) {
+        this._listeners[type] = this._listeners[type] || []
+        this._listeners[type].push(fn)
+    }
+
+    removeEventListener(type, fn) {
+        if (!this._listeners[type]) return
+        this._listeners[type] = this._listeners[type].filter((f) => f !== fn)
+    }
+
+    // Test helper: simulate the worker posting a message back
+    _postBack(data) {
+        for (const fn of this._listeners.message || []) {
+            fn({ data })
+        }
+    }
+
+    // Test helper: simulate an unrecoverable worker error
+    _fireError(err) {
+        for (const fn of this._listeners.error || []) {
+            fn(err)
+        }
+    }
+}
+
+// Test suite
+
+describe('synthesizeVerilog timeout guard', () => {
+    let synthesizeVerilog
+    let mockWorkerInstance
+
+    beforeEach(async () => {
+        vi.useFakeTimers()
+
+        vi.resetModules()
+
+        mockWorkerInstance = null
+        vi.stubGlobal('Worker', class extends MockWorker {
+            constructor(...args) {
+                super(...args)
+                mockWorkerInstance = this
+            }
+        })
+
+        const mod = await import('../src/synthesis/clientSynthesis.js')
+        synthesizeVerilog = mod.synthesizeVerilog
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+        vi.unstubAllGlobals()
+    })
+
+    //  Happy path
+
+    test('resolves when the worker returns a result before the timeout', async () => {
+        const circuitData = { name: 'test', devices: {}, connectors: [] }
+
+        const promise = synthesizeVerilog('module m; endmodule', null, { timeoutMs: 5000 })
+
+        expect(mockWorkerInstance).not.toBeNull()
+        expect(mockWorkerInstance.postMessage).toHaveBeenCalledWith({
+            type: 'synthesize',
+            code: 'module m; endmodule',
+            id: expect.any(Number),
+        })
+
+        const sentId = mockWorkerInstance.postMessage.mock.calls[0][0].id
+        mockWorkerInstance._postBack({ type: 'result', data: circuitData, id: sentId })
+
+        const result = await promise
+        expect(result).toEqual(circuitData)
+
+        vi.advanceTimersByTime(10000)
+        expect(mockWorkerInstance.terminate).not.toHaveBeenCalled()
+    })
+
+    //  Worker error path
+
+    test('rejects when the worker posts an error message', async () => {
+        const promise = synthesizeVerilog('bad code', null, { timeoutMs: 5000 })
+
+        const sentId = mockWorkerInstance.postMessage.mock.calls[0][0].id
+        mockWorkerInstance._postBack({ type: 'error', message: 'Parse error', id: sentId })
+
+        await expect(promise).rejects.toThrow('Parse error')
+        expect(mockWorkerInstance.terminate).not.toHaveBeenCalled()
+    })
+
+    //  Timeout path
+
+    test('rejects with SynthesisTimeoutError when the worker does not respond in time', async () => {
+        const promise = synthesizeVerilog('module hang; endmodule', null, { timeoutMs: 100 })
+
+        vi.advanceTimersByTime(150)
+
+        await expect(promise).rejects.toThrow('Verilog synthesis timed out after 0.1 seconds')
+
+        try {
+            await promise
+        } catch (err) {
+            expect(err.name).toBe('SynthesisTimeoutError')
+        }
+    })
+
+    test('terminates the worker on timeout', async () => {
+        const promise = synthesizeVerilog('module slow; endmodule', null, { timeoutMs: 100 })
+
+        vi.advanceTimersByTime(150)
+
+        await expect(promise).rejects.toThrow()
+        expect(mockWorkerInstance.terminate).toHaveBeenCalled()
+    })
+
+    test('creates a fresh worker after a timeout on the next call', async () => {
+        const promise1 = synthesizeVerilog('module first; endmodule', null, { timeoutMs: 100 })
+        const firstWorker = mockWorkerInstance
+
+        vi.advanceTimersByTime(150)
+        await expect(promise1).rejects.toThrow()
+
+        const promise2 = synthesizeVerilog('module second; endmodule', null, { timeoutMs: 5000 })
+        const secondWorker = mockWorkerInstance
+
+        expect(secondWorker).not.toBe(firstWorker)
+
+        const sentId = secondWorker.postMessage.mock.calls[0][0].id
+        secondWorker._postBack({ type: 'result', data: { name: 'ok' }, id: sentId })
+
+        const result = await promise2
+        expect(result).toEqual({ name: 'ok' })
+    })
+
+    //  Progress callback
+
+    test('forwards progress messages to the onProgress callback', async () => {
+        const onProgress = vi.fn()
+        const promise = synthesizeVerilog('module m; endmodule', onProgress, { timeoutMs: 5000 })
+
+        const sentId = mockWorkerInstance.postMessage.mock.calls[0][0].id
+
+        mockWorkerInstance._postBack({ type: 'progress', message: 'Loading WASM...', id: sentId })
+        mockWorkerInstance._postBack({ type: 'progress', message: 'Running Yosys...', id: sentId })
+        mockWorkerInstance._postBack({ type: 'result', data: {}, id: sentId })
+
+        await promise
+
+        expect(onProgress).toHaveBeenCalledTimes(2)
+        expect(onProgress).toHaveBeenCalledWith('Loading WASM...')
+        expect(onProgress).toHaveBeenCalledWith('Running Yosys...')
+    })
+
+    //  Default timeout
+
+    test('uses 30000ms as the default timeout when no option is provided', async () => {
+        const promise = synthesizeVerilog('module m; endmodule')
+
+        vi.advanceTimersByTime(29999)
+
+        const sentId = mockWorkerInstance.postMessage.mock.calls[0][0].id
+        mockWorkerInstance._postBack({ type: 'result', data: { name: 'done' }, id: sentId })
+
+        const result = await promise
+        expect(result).toEqual({ name: 'done' })
+    })
+
+    test('rejects at 30000ms default timeout when no option is provided', async () => {
+        const promise = synthesizeVerilog('module m; endmodule')
+
+        vi.advanceTimersByTime(30000)
+
+        await expect(promise).rejects.toThrow('Verilog synthesis timed out after 30 seconds')
+    })
+})

--- a/v1/src/simulator/spec/clientSynthesis.spec.js
+++ b/v1/src/simulator/spec/clientSynthesis.spec.js
@@ -143,6 +143,26 @@ describe('synthesizeVerilog timeout guard', () => {
         expect(result).toEqual({ name: 'ok' })
     })
 
+    //  Single in-flight guard
+
+    test('rejects a second synthesis while one is already in flight', async () => {
+        const first = synthesizeVerilog('module a; endmodule', null, { timeoutMs: 5000 })
+
+        const second = synthesizeVerilog('module b; endmodule', null, { timeoutMs: 5000 })
+        await expect(second).rejects.toThrow('already in progress')
+
+        expect(mockWorkerInstance.postMessage).toHaveBeenCalledTimes(1)
+
+        const sentId = mockWorkerInstance.postMessage.mock.calls[0][0].id
+        mockWorkerInstance._postBack({ type: 'result', data: { name: 'a' }, id: sentId })
+        await expect(first).resolves.toEqual({ name: 'a' })
+
+        const third = synthesizeVerilog('module c; endmodule', null, { timeoutMs: 5000 })
+        const thirdId = mockWorkerInstance.postMessage.mock.calls[1][0].id
+        mockWorkerInstance._postBack({ type: 'result', data: { name: 'c' }, id: thirdId })
+        await expect(third).resolves.toEqual({ name: 'c' })
+    })
+
     //  Progress callback
 
     test('forwards progress messages to the onProgress callback', async () => {

--- a/v1/src/simulator/src/Verilog2CV.js
+++ b/v1/src/simulator/src/Verilog2CV.js
@@ -32,7 +32,7 @@ import 'codemirror/addon/edit/closebrackets.js'
 import 'codemirror/addon/hint/anyword-hint.js'
 import 'codemirror/addon/hint/show-hint.js'
 import 'codemirror/addon/display/autorefresh.js'
-import { showError, showMessage } from './utils'
+import { showError, showMessage, resetPrevErrorMessage } from './utils'
 import { showProperties } from './ux'
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore'
 import { toRefs } from 'vue'
@@ -306,6 +306,7 @@ export default function generateVerilogCircuit(
     scope = globalScope
 ) {
     clearVerilogOutput()
+    resetPrevErrorMessage()
     const isDesktop = isTauri()
 
     if (isDesktop) {
@@ -341,8 +342,15 @@ export default function generateVerilogCircuit(
         })
         .catch((error) => {
             if (isDesktop) {
-                setVerilogOutput(error.message || 'Synthesis failed', 'error')
-                showError(error.message || 'Synthesis failed')
+                if (error.name === 'SynthesisTimeoutError') {
+                    var timeoutMessage =
+                        'Synthesis timed out. The worker has been reset; try again or simplify your design.'
+                    setVerilogOutput(timeoutMessage, 'error')
+                    showError(timeoutMessage)
+                } else {
+                    setVerilogOutput(error.message || 'Synthesis failed', 'error')
+                    showError(error.message || 'Synthesis failed')
+                }
             } else if (error instanceof Response) {
                 if (error.status == 500) {
                     showError('Could not connect to Yosys')

--- a/v1/src/simulator/src/Verilog2CV.js
+++ b/v1/src/simulator/src/Verilog2CV.js
@@ -32,7 +32,7 @@ import 'codemirror/addon/edit/closebrackets.js'
 import 'codemirror/addon/hint/anyword-hint.js'
 import 'codemirror/addon/hint/show-hint.js'
 import 'codemirror/addon/display/autorefresh.js'
-import { showError, showMessage, resetPrevErrorMessage } from './utils'
+import { showError, showMessage } from './utils'
 import { showProperties } from './ux'
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore'
 import { toRefs } from 'vue'
@@ -306,7 +306,6 @@ export default function generateVerilogCircuit(
     scope = globalScope
 ) {
     clearVerilogOutput()
-    resetPrevErrorMessage()
     const isDesktop = isTauri()
 
     if (isDesktop) {

--- a/v1/src/simulator/src/synthesis/clientSynthesis.js
+++ b/v1/src/simulator/src/synthesis/clientSynthesis.js
@@ -2,14 +2,20 @@
 
 var worker = null
 var requestId = 0
+var busy = false
 
 var DEFAULT_SYNTHESIS_TIMEOUT_MS = 30000
 
 // abort + reset the worker if synthesis runs longer (default 30s).
 export function synthesizeVerilog(verilogCode, onProgress, options = {}) {
-    var timeoutMs = options.timeoutMs || DEFAULT_SYNTHESIS_TIMEOUT_MS
+    var timeoutMs = options.timeoutMs ?? DEFAULT_SYNTHESIS_TIMEOUT_MS
 
     return new Promise((resolve, reject) => {
+        if (busy) {
+            reject(new Error('A Verilog synthesis is already in progress'))
+            return
+        }
+
         if (!worker) {
             try {
                 worker = new Worker(new URL('./synthesisWorker.js', import.meta.url), { type: 'module' })
@@ -22,6 +28,7 @@ export function synthesizeVerilog(verilogCode, onProgress, options = {}) {
         var id = ++requestId
         var timer = null
         var currentWorker = worker
+        busy = true
 
         function handleMessage(e) {
             if (e.data.id !== id) return
@@ -51,6 +58,7 @@ export function synthesizeVerilog(verilogCode, onProgress, options = {}) {
         }
 
         function cleanup() {
+            busy = false
             clearTimeout(timer)
             currentWorker.removeEventListener('message', handleMessage)
             currentWorker.removeEventListener('error', handleError)

--- a/v1/src/simulator/src/synthesis/clientSynthesis.js
+++ b/v1/src/simulator/src/synthesis/clientSynthesis.js
@@ -3,7 +3,12 @@
 var worker = null
 var requestId = 0
 
-export function synthesizeVerilog(verilogCode, onProgress) {
+var DEFAULT_SYNTHESIS_TIMEOUT_MS = 30000
+
+// abort + reset the worker if synthesis runs longer (default 30s).
+export function synthesizeVerilog(verilogCode, onProgress, options = {}) {
+    var timeoutMs = options.timeoutMs || DEFAULT_SYNTHESIS_TIMEOUT_MS
+
     return new Promise((resolve, reject) => {
         if (!worker) {
             try {
@@ -15,6 +20,8 @@ export function synthesizeVerilog(verilogCode, onProgress) {
         }
 
         var id = ++requestId
+        var timer = null
+        var currentWorker = worker
 
         function handleMessage(e) {
             if (e.data.id !== id) return
@@ -38,21 +45,33 @@ export function synthesizeVerilog(verilogCode, onProgress) {
 
         function handleError(err) {
             cleanup()
-            worker.terminate()
-            worker = null
+            currentWorker.terminate()
+            if (worker === currentWorker) worker = null
             reject(new Error('Synthesis worker error: ' + (err.message || 'Unknown error')))
         }
 
         function cleanup() {
-            worker.removeEventListener('message', handleMessage)
-            worker.removeEventListener('error', handleError)
+            clearTimeout(timer)
+            currentWorker.removeEventListener('message', handleMessage)
+            currentWorker.removeEventListener('error', handleError)
         }
 
-        worker.addEventListener('message', handleMessage)
-        worker.addEventListener('error', handleError)
+        currentWorker.addEventListener('message', handleMessage)
+        currentWorker.addEventListener('error', handleError)
+
+        timer = setTimeout(() => {
+            cleanup()
+            currentWorker.terminate()
+            if (worker === currentWorker) worker = null
+            var error = new Error(
+                'Verilog synthesis timed out after ' + (timeoutMs / 1000) + ' seconds'
+            )
+            error.name = 'SynthesisTimeoutError'
+            reject(error)
+        }, timeoutMs)
 
         try {
-            worker.postMessage({ type: 'synthesize', code: verilogCode, id: id })
+            currentWorker.postMessage({ type: 'synthesize', code: verilogCode, id: id })
         } catch (err) {
             cleanup()
             reject(new Error('Failed to send code to synthesis worker: ' + err.message))

--- a/v1/src/simulator/src/utils.ts
+++ b/v1/src/simulator/src/utils.ts
@@ -61,11 +61,6 @@ export function showError(error: string) {
   useActions().showMessage(error, "error");
 }
 
-// Reset the error dedup guard so the same error can be shown again.
-export function resetPrevErrorMessage() {
-  prevErrorMessage = undefined;
-}
-
 // Helper function to show message
 export function showMessage(mes: string) {
   if (mes === prevShowMessage) return;

--- a/v1/src/simulator/src/utils.ts
+++ b/v1/src/simulator/src/utils.ts
@@ -61,6 +61,11 @@ export function showError(error: string) {
   useActions().showMessage(error, "error");
 }
 
+// Reset the error dedup guard so the same error can be shown again.
+export function resetPrevErrorMessage() {
+  prevErrorMessage = undefined;
+}
+
 // Helper function to show message
 export function showMessage(mes: string) {
   if (mes === prevShowMessage) return;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,10 @@ import vuetify from "vite-plugin-vuetify";
 import VueI18nPlugin from "@intlify/unplugin-vue-i18n/vite";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 
-const synthesisSpecs = ["v1/src/simulator/spec/synthesis.spec.js"];
+const synthesisSpecs = [
+  "v1/src/simulator/spec/synthesis.spec.js",
+  "v1/src/simulator/spec/clientSynthesis.spec.js",
+];
 
 const createProjectConfig = (version: string) => ({
   plugins: [


### PR DESCRIPTION
Fixes #1083

<!-- Add issue number above -->

**Note : stacked PR:** This change is built on top of #1111 (client-side Verilog synthesis). Until #1111 merges, the diff here will also include the synthesis files (`circuitLayout.js`, `synthesisWorker.js`, `clientSynthesis.js`, etc.). The only new change introduced by this PR is the 30s timeout guard, see `clientSynthesis.js`, `Verilog2CV.js`, and the new `clientSynthesis.spec.js`. Once #1111 merges, this diff will reduce to just the timeout commit.

### Describe the changes you have made in this PR -

Added a timeout guard to the client-side Verilog synthesis worker for the Tauri desktop app to prevent the UI from hanging indefinitely on pathological Verilog input.
- Implemented a configurable `DEFAULT_SYNTHESIS_TIMEOUT_MS` (30 seconds) in `v1/src/simulator/src/synthesis/clientSynthesis.js`.
- Starts a timer when a synthesis request is dispatched to the Web Worker.
- If the timeout expires before a result or error is received, the worker is forcibly terminated, event listeners are cleaned up, and the promise rejects with a `SynthesisTimeoutError`.
- Ensures a fresh Web Worker is lazily created for the next synthesis request if the previous one was terminated.
- Handled the timeout error in the UI (`v1/src/simulator/src/Verilog2CV.js`) to display an appropriate error message to the user and reset the error guard (`resetPrevErrorMessage`).
- Added comprehensive Vitest coverage in a Node environment to verify timeout behavior, worker termination, error handling, and progress callbacks.
- **Note:** This feature is strictly scoped to the `v1` simulator.

**Note: I chose 30 s to mirror the existing server-side synthesis timeout (the Rails `read: 30` in `simulator_controller.rb#` http_client) [Here](https://github.com/CircuitVerse/CircuitVerse/blob/master/app/controllers/simulator_controller.rb#L162), keeping client and server behavior consistent.**

### Screenrecording (Manually verified the timeout path by temporarily lowering the limit to 3 ms to force a timeout, confirmed the worker terminates, the error surfaces in the UI, and the next run recovers with a fresh worker, then restored it to 30 sec.)-


https://github.com/user-attachments/assets/40fc4a45-1cce-4c64-a0cf-f731a267f791




---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

### Explain your implementation approach:

This PR solves the issue where the YoWASP/Yosys Web Worker could hang indefinitely on complex or malformed Verilog input, leaving the UI stuck in a pending state and silently consuming CPU resources in the background.

I considered implementing the timeout directly inside the Web Worker itself. However, since Yosys runs as a synchronous WebAssembly module that blocks the worker's thread, the worker wouldn't be able to process its own cancellation events reliably while busy. I also considered `AbortController`, but it doesn't easily interrupt the synchronous WASM execution.

Therefore, I chose to implement the timeout on the main thread (`clientSynthesis.js`). By wrapping the request in a `setTimeout`, we can forcibly call `worker.terminate()` if it exceeds the 30-second limit. This guarantees the runaway process is killed and the UI can recover. The `synthesizeVerilog` function handles this lifecycle, tracking the worker instance and resetting it to `null` upon termination so the next call spins up a fresh worker.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verilog synthesis now supports progress updates, request timeouts, and clearer handling when multiple requests are made.
  * Timeout behavior defaults to 30 seconds if no custom value is provided.

* **Bug Fixes**
  * Improved error messages for synthesis timeouts and worker failures.
  * After a timeout or failure, the next synthesis attempt starts cleanly with a fresh worker.

* **Tests**
  * Added coverage for successful synthesis, errors, timeouts, progress updates, and concurrent request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
