### PR TITLE
feat: add client-side Verilog synthesis via YoWASP WASM for offline Tauri desktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@tiptap/extension-underline": "^2.0.3",
         "@tiptap/starter-kit": "^2.0.3",
         "@tiptap/vue-3": "^2.0.3",
-        "@yowasp/yosys": "^0.59.84-dev.1027",
+        "@yowasp/yosys": "0.59.84-dev.1027",
         "bootstrap": "^4.6.1",
         "canvas-to-svg": "^1.0.3",
         "codemirror": "^5.65.1",
@@ -3495,9 +3495,9 @@
       }
     },
     "node_modules/@yowasp/yosys": {
-      "version": "0.59.1038",
-      "resolved": "https://registry.npmjs.org/@yowasp/yosys/-/yosys-0.59.1038.tgz",
-      "integrity": "sha512-hNtR1wwrtZs1r8ihcbcZFrfjGuuhSY+U/8WB8ccyWflO3OSCth2c8CRxfxcK7Z8pKC0xT2SnfLqaMKg2R+/RIQ==",
+      "version": "0.59.84-dev.1027",
+      "resolved": "https://registry.npmjs.org/@yowasp/yosys/-/yosys-0.59.84-dev.1027.tgz",
+      "integrity": "sha512-3e3baqUNO0ktkRxJIdUFQWKKEGWueMxqftyHuGq/Ajhklr1APyEKR79knQohXcOq0A/u0sbpZh0xKYE9EK3p/w==",
       "license": "ISC"
     },
     "node_modules/3vl": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@tiptap/extension-underline": "^2.0.3",
         "@tiptap/starter-kit": "^2.0.3",
         "@tiptap/vue-3": "^2.0.3",
+        "@yowasp/yosys": "^0.59.84-dev.1027",
         "bootstrap": "^4.6.1",
         "canvas-to-svg": "^1.0.3",
         "codemirror": "^5.65.1",
@@ -36,7 +37,8 @@
         "vue-router": "^4.6.4",
         "vuedraggable": "^4.1.0",
         "vuetify": "^3.7.9",
-        "webfontloader": "^1.0.0"
+        "webfontloader": "^1.0.0",
+        "yosys2digitaljs": "^0.10.3"
       },
       "devDependencies": {
         "@commitlint/cli": "^19.0.0",
@@ -3492,6 +3494,18 @@
         "vuetify": ">=3"
       }
     },
+    "node_modules/@yowasp/yosys": {
+      "version": "0.59.1038",
+      "resolved": "https://registry.npmjs.org/@yowasp/yosys/-/yosys-0.59.1038.tgz",
+      "integrity": "sha512-hNtR1wwrtZs1r8ihcbcZFrfjGuuhSY+U/8WB8ccyWflO3OSCth2c8CRxfxcK7Z8pKC0xT2SnfLqaMKg2R+/RIQ==",
+      "license": "ISC"
+    },
+    "node_modules/3vl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/3vl/-/3vl-1.0.1.tgz",
+      "integrity": "sha512-Z75UMwicaLbb3p1FjL1cBxGq/rpJIv73h5LtHl3FWD7vfOSjxzU37LAYhyMYul4tZa0wZtsJHtqCYeisIsVlJw==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/abbrev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
@@ -3588,6 +3602,19 @@
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -3598,6 +3625,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3605,6 +3647,15 @@
       "dev": true,
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.52",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+      "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/birpc": {
@@ -3663,6 +3714,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -4114,6 +4212,40 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -4149,6 +4281,20 @@
       "version": "0.9.8",
       "resolved": "https://registry.npmjs.org/driver.js/-/driver.js-0.9.8.tgz",
       "integrity": "sha512-bczjyKdX6XmFyCDkwtRmlaORDwfBk1xXmRO0CAe5VwNQTM98aWaG2LAIiIdTe53iV/B7W5lXlIy2xYtf0JRb7Q=="
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -4239,12 +4385,42 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -4754,6 +4930,21 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4783,6 +4974,24 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -4790,6 +4999,43 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/git-raw-commits": {
@@ -4889,11 +5135,83 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hashmap": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/hashmap/-/hashmap-2.4.0.tgz",
+      "integrity": "sha512-Ngj48lhnxJdnBAEVbubKBJuN1elfVLZJs94ZixRi98X3GCU4v6pgj9qRkHt6H8WaVJ69Wv0r1GhtS7hvF9zCgg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -5035,6 +5353,12 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/ini": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.1.tgz",
@@ -5052,11 +5376,39 @@
         "@interactjs/types": "1.10.27"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -5076,6 +5428,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -5086,6 +5457,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-number": {
@@ -5112,6 +5499,24 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-text-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
@@ -5122,6 +5527,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-what": {
@@ -5857,6 +6277,15 @@
         "node": ">= 12"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -5927,7 +6356,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6038,6 +6466,51 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
       "dev": true
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.3",
@@ -6363,6 +6836,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -6754,11 +7236,37 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
     "node_modules/sass": {
       "version": "1.100.0",
@@ -6802,6 +7310,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -7116,6 +7641,24 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true
     },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7126,6 +7669,14 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/topsort": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/topsort/-/topsort-0.0.2.tgz",
+      "integrity": "sha512-LFOhv352rEso8p3YG1ZfL31t6lX09es2XVUr7O04RgvnUXxlRyAKcYiIiG9iouFkKf8HMo94IH1BVaqw6ZXarw==",
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
     "node_modules/tough-cookie": {
@@ -7150,6 +7701,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-api-utils": {
@@ -7263,6 +7823,25 @@
       "peer": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/vite": {
@@ -7683,6 +8262,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -7960,6 +8560,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yosys2digitaljs": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/yosys2digitaljs/-/yosys2digitaljs-0.10.3.tgz",
+      "integrity": "sha512-mjYisz3tfAvO2X5+bRH8Jf2cxzsGmn3n9mXFzviskqVFCrz7Zi4ENpEEjDT1fKvn162T5bD5/gDCV3meW4lNRw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "3vl": "^1.0.1",
+        "assert": "^2.1.0",
+        "big-integer": "^1.6.52",
+        "hashmap": "^2.4.0",
+        "minimist": "^1.2.8",
+        "sanitize-filename": "^1.6.3",
+        "tmp-promise": "^3.0.3",
+        "topsort": "^0.0.2"
+      },
+      "engines": {
+        "node": ">=8.11.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format:check": "oxfmt --check \"**/*.ts\"",
     "fmt:check": "npm run format:check",
     "postinstall": "husky install",
-    "test": "vitest --silent"
+    "test": "vitest --silent",
+    "test:synthesis": "vitest run --project synthesis"
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.5.1",
@@ -30,6 +31,7 @@
     "@tiptap/extension-underline": "^2.0.3",
     "@tiptap/starter-kit": "^2.0.3",
     "@tiptap/vue-3": "^2.0.3",
+    "@yowasp/yosys": "^0.59.84-dev.1027",
     "bootstrap": "^4.6.1",
     "canvas-to-svg": "^1.0.3",
     "codemirror": "^5.65.1",
@@ -44,7 +46,8 @@
     "vue-router": "^4.6.4",
     "vuedraggable": "^4.1.0",
     "vuetify": "^3.7.9",
-    "webfontloader": "^1.0.0"
+    "webfontloader": "^1.0.0",
+    "yosys2digitaljs": "^0.10.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@tiptap/extension-underline": "^2.0.3",
     "@tiptap/starter-kit": "^2.0.3",
     "@tiptap/vue-3": "^2.0.3",
-    "@yowasp/yosys": "^0.59.84-dev.1027",
+    "@yowasp/yosys": "0.59.84-dev.1027",
     "bootstrap": "^4.6.1",
     "canvas-to-svg": "^1.0.3",
     "codemirror": "^5.65.1",

--- a/v1/src/simulator/spec/synthesis.spec.js
+++ b/v1/src/simulator/spec/synthesis.spec.js
@@ -1,0 +1,180 @@
+import { describe, test, expect } from 'vitest'
+import { computeLayout, computePortLayout } from '../src/synthesis/circuitLayout.js';
+
+// Tests for the client-side Verilog synthesis module.
+
+describe('Circuit Auto-Layout (computeLayout)', () => {
+
+    test('returns empty object for empty circuit', () => {
+        const result = computeLayout({ devices: {}, connectors: [] })
+        expect(result).toEqual({})
+    })
+
+    test('returns empty object for missing devices', () => {
+        const result = computeLayout({})
+        expect(result).toEqual({})
+    })
+
+    test('returns empty object for null or undefined input', () => {
+        expect(computeLayout(null)).toEqual({})
+        expect(computeLayout(undefined)).toEqual({})
+    })
+
+    test('assigns positions to a single device', () => {
+        const circuit = {
+            devices: {
+                dev1: { type: 'And' }
+            },
+            connectors: []
+        }
+        const positions = computeLayout(circuit)
+        expect(positions).toHaveProperty('dev1')
+        expect(positions.dev1).toHaveProperty('x')
+        expect(positions.dev1).toHaveProperty('y')
+        expect(typeof positions.dev1.x).toBe('number')
+        expect(typeof positions.dev1.y).toBe('number')
+    })
+
+    test('assigns positions to all devices in a connected circuit', () => {
+        // Simple: Input → AND gate → Output
+        const circuit = {
+            devices: {
+                in1: { type: 'Input' },
+                in2: { type: 'Input' },
+                and1: { type: 'And' },
+                out1: { type: 'Output' }
+            },
+            connectors: [
+                { from: { id: 'in1', port: 'out' }, to: { id: 'and1', port: 'in1' } },
+                { from: { id: 'in2', port: 'out' }, to: { id: 'and1', port: 'in2' } },
+                { from: { id: 'and1', port: 'out' }, to: { id: 'out1', port: 'in' } }
+            ]
+        }
+        const positions = computeLayout(circuit)
+
+        // All 4 devices should have positions
+        expect(Object.keys(positions)).toHaveLength(4)
+        expect(positions).toHaveProperty('in1')
+        expect(positions).toHaveProperty('in2')
+        expect(positions).toHaveProperty('and1')
+        expect(positions).toHaveProperty('out1')
+    })
+
+    test('places connected devices in left-to-right layer order', () => {
+        // Input → AND → Output should produce x(Input) < x(AND) < x(Output)
+        const circuit = {
+            devices: {
+                input: { type: 'Input' },
+                gate: { type: 'And' },
+                output: { type: 'Output' }
+            },
+            connectors: [
+                { from: { id: 'input', port: 'out' }, to: { id: 'gate', port: 'in1' } },
+                { from: { id: 'gate', port: 'out' }, to: { id: 'output', port: 'in' } }
+            ]
+        }
+        const positions = computeLayout(circuit)
+
+        expect(positions.input.x).toBeLessThan(positions.gate.x)
+        expect(positions.gate.x).toBeLessThan(positions.output.x)
+    })
+
+    test('produces non-overlapping positions', () => {
+        // 4 devices — verify no two share the same (x, y)
+        const circuit = {
+            devices: {
+                a: { type: 'Input' },
+                b: { type: 'Input' },
+                c: { type: 'And' },
+                d: { type: 'Output' }
+            },
+            connectors: [
+                { from: { id: 'a', port: 'out' }, to: { id: 'c', port: 'in1' } },
+                { from: { id: 'b', port: 'out' }, to: { id: 'c', port: 'in2' } },
+                { from: { id: 'c', port: 'out' }, to: { id: 'd', port: 'in' } }
+            ]
+        }
+        const positions = computeLayout(circuit)
+        const coords = Object.values(positions)
+
+        // No two devices should have the exact same position
+        for (let i = 0; i < coords.length; i++) {
+            for (let j = i + 1; j < coords.length; j++) {
+                const samePos = coords[i].x === coords[j].x && coords[i].y === coords[j].y
+                expect(samePos).toBe(false)
+            }
+        }
+    })
+
+    test('handles disconnected devices without crashing', () => {
+        const circuit = {
+            devices: {
+                a: { type: 'Input' },
+                b: { type: 'Output' }
+            },
+            connectors: [] // No connections
+        }
+        const positions = computeLayout(circuit)
+        expect(Object.keys(positions)).toHaveLength(2)
+        expect(positions).toHaveProperty('a')
+        expect(positions).toHaveProperty('b')
+    })
+
+    test('handles unknown device types with default sizing', () => {
+        const circuit = {
+            devices: {
+                custom1: { type: 'SomeCustomGate' },
+                custom2: { type: 'AnotherGate' }
+            },
+            connectors: [
+                { from: { id: 'custom1', port: 'out' }, to: { id: 'custom2', port: 'in' } }
+            ]
+        }
+        // Should not throw — uses DEFAULT_SIZE fallback
+        const positions = computeLayout(circuit)
+        expect(Object.keys(positions)).toHaveLength(2)
+    })
+})
+
+describe('Verilog Port Layout (computePortLayout)', () => {
+    test('places two inputs on the left and centers one output on the right', () => {
+        const portLayout = computePortLayout(2, 1);
+
+        expect(portLayout.layout).toMatchObject({
+            width: 120,
+            height: 70,
+            title_x: 60,
+            title_y: 13,
+            titleEnabled: true,
+        });
+        expect(portLayout.inputs).toEqual([
+            { x: 0, y: 30 },
+            { x: 0, y: 50 },
+        ]);
+        expect(portLayout.outputs).toEqual([
+            { x: 120, y: 40 },
+        ]);
+    });
+
+    test('keeps layout valid for modules without ports', () => {
+        const portLayout = computePortLayout(0, 0);
+
+        expect(portLayout.layout.height).toBe(50);
+        expect(portLayout.inputs).toEqual([]);
+        expect(portLayout.outputs).toEqual([]);
+    });
+
+    test('centers the smaller port side for uneven module interfaces', () => {
+        const portLayout = computePortLayout(1, 3);
+
+        expect(portLayout.layout.height).toBe(90);
+        expect(portLayout.inputs).toEqual([
+            { x: 0, y: 50 },
+        ]);
+        expect(portLayout.outputs).toEqual([
+            { x: 120, y: 30 },
+            { x: 120, y: 50 },
+            { x: 120, y: 70 },
+        ]);
+    });
+});

--- a/v1/src/simulator/src/Verilog2CV.js
+++ b/v1/src/simulator/src/Verilog2CV.js
@@ -341,6 +341,7 @@ export default function generateVerilogCircuit(
         })
         .catch((error) => {
             if (isDesktop) {
+                setVerilogOutput(error.message || 'Synthesis failed', 'error')
                 showError(error.message || 'Synthesis failed')
             } else if (error instanceof Response) {
                 if (error.status == 500) {

--- a/v1/src/simulator/src/Verilog2CV.js
+++ b/v1/src/simulator/src/Verilog2CV.js
@@ -346,6 +346,7 @@ export default function generateVerilogCircuit(
             } else if (error instanceof Response) {
                 if (error.status == 500) {
                     showError('Could not connect to Yosys')
+                    setVerilogOutput('Could not connect to Yosys', 'error')
                 } else {
                     showError('There is some issue with the code')
                     error.json()

--- a/v1/src/simulator/src/Verilog2CV.js
+++ b/v1/src/simulator/src/Verilog2CV.js
@@ -3,6 +3,9 @@ import {
     switchCircuit,
     changeCircuitName,
 } from './circuit'
+import { synthesizeVerilog } from './synthesis/clientSynthesis.js'
+import { computeLayout, computePortLayout } from './synthesis/circuitLayout.js';
+import { isTauri } from '@tauri-apps/api/core'
 import SubCircuit from './subcircuit'
 import { simulationArea } from './simulationArea'
 import CodeMirror from 'codemirror/lib/codemirror.js'
@@ -66,6 +69,35 @@ export function saveVerilogCode() {
 export function applyVerilogTheme(theme) {
     localStorage.setItem('verilog-theme', theme)
     editor.setOption('theme', theme)
+}
+
+function setVerilogOutput(text, type = 'info') {
+    if (typeof window !== 'undefined' && window.verilogTerminal) {
+        window.verilogTerminal.addMessage(text, type)
+    } else {
+        const verilogOutputDiv = document.getElementById('verilogOutput')
+        if (verilogOutputDiv) {
+            verilogOutputDiv.textContent = text
+            if (type === 'error') {
+                verilogOutputDiv.style.color = '#ff6b6b'
+            } else if (type === 'success') {
+                verilogOutputDiv.style.color = '#51cf66'
+            } else {
+                verilogOutputDiv.style.color = ''
+            }
+        }
+    }
+}
+
+function clearVerilogOutput() {
+    if (typeof window !== 'undefined' && window.verilogTerminal) {
+        window.verilogTerminal.clearOutput()
+    } else {
+        const verilogOutputDiv = document.getElementById('verilogOutput')
+        if (verilogOutputDiv) {
+            verilogOutputDiv.innerHTML = ''
+        }
+    }
 }
 
 export function resetVerilogCode() {
@@ -158,6 +190,22 @@ class verilogSubCircuit {
     }
 }
 
+function applyVerilogPortLayout(scope) {
+    var portLayout = computePortLayout(scope.Input.length, scope.Output.length);
+
+    Object.assign(scope.layout, portLayout.layout);
+
+    for (var i = 0; i < scope.Input.length; i++) {
+        scope.Input[i].layoutProperties.x = portLayout.inputs[i].x;
+        scope.Input[i].layoutProperties.y = portLayout.inputs[i].y;
+    }
+
+    for (var j = 0; j < scope.Output.length; j++) {
+        scope.Output[j].layoutProperties.x = portLayout.outputs[j].x;
+        scope.Output[j].layoutProperties.y = portLayout.outputs[j].y;
+    }
+}
+
 export function YosysJSON2CV(
     JSON,
     parentScope = globalScope,
@@ -203,6 +251,18 @@ export function YosysJSON2CV(
         }
     }
 
+    applyVerilogPortLayout(subScope);
+
+    // Auto-layout: compute non-overlapping positions
+    var layoutPositions = computeLayout(JSON)
+    for (var deviceId in circuitDevices) {
+        var pos = layoutPositions[deviceId]
+        if (pos && circuitDevices[deviceId].element) {
+            circuitDevices[deviceId].element.x = pos.x
+            circuitDevices[deviceId].element.y = pos.y
+        }
+    }
+
     for (var connection in JSON.connectors) {
         var fromId = JSON.connectors[connection]['from']['id']
         var fromPort = JSON.connectors[connection]['from']['port']
@@ -224,24 +284,43 @@ export function YosysJSON2CV(
     }
 }
 
-export default function generateVerilogCircuit(
-    verilogCode,
-    scope = globalScope
-) {
-    var params = { code: verilogCode }
-    fetch('/api/v1/simulator/verilogcv', {
+// Platform detection: Tauri desktop app vs. web browser
+
+function serverSynthesis(verilogCode) {
+    return fetch('/api/v1/simulator/verilogcv', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
         },
-        body: JSON.stringify(params),
+        body: JSON.stringify({ code: verilogCode }),
+    }).then((response) => {
+        if (!response.ok) {
+            throw response
+        }
+        return response.json()
     })
-        .then((response) => {
-            if (!response.ok) {
-                throw response
-            }
-            return response.json()
+}
+
+export default function generateVerilogCircuit(
+    verilogCode,
+    scope = globalScope
+) {
+    clearVerilogOutput()
+    const isDesktop = isTauri()
+
+    if (isDesktop) {
+        setVerilogOutput('Compiling Verilog (offline, WASM)...', 'info')
+    } else {
+        setVerilogOutput('Compiling Verilog code...', 'info')
+    }
+
+    var synthesisPromise = isDesktop
+        ? synthesizeVerilog(verilogCode, (progress) => {
+            setVerilogOutput(progress, 'info')
         })
+        : serverSynthesis(verilogCode)
+
+    synthesisPromise
         .then((circuitData) => {
             scope.initialize()
             for (var id in scope.verilogMetadata.subCircuitScopeIds)
@@ -258,17 +337,26 @@ export default function generateVerilogCircuit(
             )
             changeCircuitName(circuitData.name)
             showMessage('Verilog Circuit Successfully Created')
-            document.getElementById('verilogOutput').innerHTML = ''
+            clearVerilogOutput()
         })
         .catch((error) => {
-            if (error.status == 500) {
-                showError('Could not connect to Yosys')
+            if (isDesktop) {
+                showError(error.message || 'Synthesis failed')
+            } else if (error instanceof Response) {
+                if (error.status == 500) {
+                    showError('Could not connect to Yosys')
+                } else {
+                    showError('There is some issue with the code')
+                    error.json()
+                        .then((errorMessage) => {
+                            setVerilogOutput(errorMessage.message, 'error')
+                        })
+                        .catch(() => {
+                            setVerilogOutput('Server returned a non-JSON error response', 'error')
+                        })
+                }
             } else {
-                showError('There is some issue with the code')
-                error.json().then((errorMessage) => {
-                    document.getElementById('verilogOutput').innerHTML =
-                        errorMessage.message
-                })
+                showError(error.message || 'Could not reach the synthesis server')
             }
         })
 }

--- a/v1/src/simulator/src/layoutMode.ts
+++ b/v1/src/simulator/src/layoutMode.ts
@@ -113,11 +113,13 @@ export function renderLayout(scope = globalScope) {
     if (!tempBuffer.Input[i].label) continue;
     info = determineLabel(tempBuffer.Input[i].x, tempBuffer.Input[i].y, scope);
     [ctx.textAlign] = info;
+    const xOffset = typeof info[1] === "number" ? info[1] : parseInt(info[1] as string);
+    const yOffset = typeof info[2] === "number" ? info[2] : parseInt(info[2] as string);
     fillText(
       ctx,
       tempBuffer.Input[i].label,
-      tempBuffer.Input[i].x + typeof info[1] === "number" ? info[1] : parseInt(info[1] as string),
-      tempBuffer.Input[i].y + typeof info[2] === "number" ? info[2] : parseInt(info[2] as string),
+      tempBuffer.Input[i].x + xOffset,
+      tempBuffer.Input[i].y + yOffset,
       12,
     );
   }
@@ -125,11 +127,13 @@ export function renderLayout(scope = globalScope) {
     if (!tempBuffer.Output[i].label) continue;
     info = determineLabel(tempBuffer.Output[i].x, tempBuffer.Output[i].y, scope);
     [ctx.textAlign] = info;
+    const xOffset = typeof info[1] === "number" ? info[1] : parseInt(info[1] as string);
+    const yOffset = typeof info[2] === "number" ? info[2] : parseInt(info[2] as string);
     fillText(
       ctx,
       tempBuffer.Output[i].label,
-      tempBuffer.Output[i].x + typeof info[1] === "number" ? info[1] : parseInt(info[1] as string),
-      tempBuffer.Output[i].y + typeof info[2] === "number" ? info[2] : parseInt(info[2] as string),
+      tempBuffer.Output[i].x + xOffset,
+      tempBuffer.Output[i].y + yOffset,
       12,
     );
   }

--- a/v1/src/simulator/src/subcircuit.ts
+++ b/v1/src/simulator/src/subcircuit.ts
@@ -530,8 +530,8 @@ export default class SubCircuit extends CircuitElement {
    * determines where to show label
    */
   determine_label(x: number, y: number): [string, number, number] {
-    if (x == 0) return ["left", 5, 5];
-    if (x == scopeList[this.id].layout.width) return ["right", -5, 5];
+    if (x == 0) return ["left", 5, 0];
+    if (x == scopeList[this.id].layout.width) return ["right", -5, 0];
     if (y == 0) return ["center", 0, 13];
     return ["center", 0, -6];
   }

--- a/v1/src/simulator/src/synthesis/circuitLayout.js
+++ b/v1/src/simulator/src/synthesis/circuitLayout.js
@@ -26,6 +26,9 @@ var LAYER_GAP = 160
 var NODE_GAP = 80    
 var MARGIN_X = 80     
 var MARGIN_Y = 80     
+// Nominal canvas height (px) used as a reference to vertically center each layer's nodes
+var LAYER_VIEWPORT_HEIGHT = 400
+
 var PORT_LAYOUT_WIDTH = 120;
 var PORT_LAYOUT_START_Y = 30;
 var PORT_LAYOUT_GAP = 20;
@@ -154,7 +157,7 @@ export function computeLayout(circuitJSON) {
             }
             totalHeight += (nodesInLayer.length - 1) * NODE_GAP
 
-            var startY = MARGIN_Y + Math.max(0, (400 - totalHeight) / 2)
+            var startY = MARGIN_Y + Math.max(0, (LAYER_VIEWPORT_HEIGHT - totalHeight) / 2)
             var currentY = startY
 
             for (var p = 0; p < nodesInLayer.length; p++) {

--- a/v1/src/simulator/src/synthesis/circuitLayout.js
+++ b/v1/src/simulator/src/synthesis/circuitLayout.js
@@ -1,0 +1,176 @@
+// Circuit auto-layout using topological sort (no external deps).
+ 
+var DEVICE_SIZES = {
+    Input: { width: 60, height: 40 },
+    Output: { width: 60, height: 40 },
+    Clock: { width: 60, height: 40 },
+    Button: { width: 60, height: 40 },
+    Lamp: { width: 40, height: 40 },
+    And: { width: 60, height: 40 },
+    Nand: { width: 60, height: 40 },
+    Or: { width: 60, height: 40 },
+    Nor: { width: 60, height: 40 },
+    Xor: { width: 60, height: 40 },
+    Xnor: { width: 60, height: 40 },
+    Not: { width: 50, height: 30 },
+    Repeater: { width: 50, height: 30 },
+    Mux: { width: 60, height: 80 },
+    Dff: { width: 80, height: 60 },
+    Subcircuit: { width: 120, height: 80 },
+    Constant: { width: 60, height: 30 },
+}
+
+var DEFAULT_SIZE = { width: 70, height: 50 }
+
+var LAYER_GAP = 160   
+var NODE_GAP = 80    
+var MARGIN_X = 80     
+var MARGIN_Y = 80     
+var PORT_LAYOUT_WIDTH = 120;
+var PORT_LAYOUT_START_Y = 30;
+var PORT_LAYOUT_GAP = 20;
+var PORT_LAYOUT_BOTTOM_PADDING = 20;
+var PORT_LAYOUT_TITLE_Y = 13;
+
+// Compute subcircuit shell port layout
+export function computePortLayout(inputCount, outputCount) {
+    var inputs = Math.max(0, inputCount || 0);
+    var outputs = Math.max(0, outputCount || 0);
+    var maxPorts = Math.max(inputs, outputs, 1);
+    var height = PORT_LAYOUT_START_Y + (maxPorts - 1) * PORT_LAYOUT_GAP + PORT_LAYOUT_BOTTOM_PADDING;
+
+    function positions(count, x) {
+        var result = [];
+        var startY = PORT_LAYOUT_START_Y + ((maxPorts - count) * PORT_LAYOUT_GAP) / 2;
+        for (var i = 0; i < count; i++) {
+            result.push({
+                x: x,
+                y: startY + i * PORT_LAYOUT_GAP,
+            });
+        }
+        return result;
+    }
+
+    return {
+        layout: {
+            width: PORT_LAYOUT_WIDTH,
+            height: height,
+            title_x: PORT_LAYOUT_WIDTH / 2,
+            title_y: PORT_LAYOUT_TITLE_Y,
+            titleEnabled: true,
+        },
+        inputs: positions(inputs, 0),
+        outputs: positions(outputs, PORT_LAYOUT_WIDTH),
+    };
+}
+
+// Topological layered layout for a DigitalJS circuit
+export function computeLayout(circuitJSON) {
+    if (!circuitJSON || !circuitJSON.devices || Object.keys(circuitJSON.devices).length === 0) {
+        return {}
+    }
+
+    try {
+        var deviceIds = Object.keys(circuitJSON.devices)
+
+        // Build adjacency lists
+        var successors = {}
+        var inDegree = {}
+        for (var i = 0; i < deviceIds.length; i++) {
+            successors[deviceIds[i]] = []
+            inDegree[deviceIds[i]] = 0
+        }
+
+        if (circuitJSON.connectors) {
+            for (var j = 0; j < circuitJSON.connectors.length; j++) {
+                var conn = circuitJSON.connectors[j]
+                var fromId = conn.from.id
+                var toId = conn.to.id
+                if (successors[fromId] !== undefined && inDegree[toId] !== undefined) {
+                    successors[fromId].push(toId)
+                    inDegree[toId]++
+                }
+            }
+        }
+
+        // Topological sort using Kahn's algorithm to assign layers
+        var queue = []
+        var layerOf = {}
+        for (var k = 0; k < deviceIds.length; k++) {
+            if (inDegree[deviceIds[k]] === 0) {
+                queue.push(deviceIds[k])
+                layerOf[deviceIds[k]] = 0
+            }
+        }
+
+        var sorted = []
+        while (queue.length > 0) {
+            var node = queue.shift()
+            sorted.push(node)
+            var succs = successors[node]
+            for (var s = 0; s < succs.length; s++) {
+                var next = succs[s]
+                var nextLayer = (layerOf[node] || 0) + 1
+                if (layerOf[next] === undefined || nextLayer > layerOf[next]) {
+                    layerOf[next] = nextLayer
+                }
+                inDegree[next]--
+                if (inDegree[next] === 0) {
+                    queue.push(next)
+                }
+            }
+        }
+
+        // Handle any nodes not reached (cycles or disconnected)
+        for (var m = 0; m < deviceIds.length; m++) {
+            if (layerOf[deviceIds[m]] === undefined) {
+                layerOf[deviceIds[m]] = 0
+            }
+        }
+
+        // Group devices by layer
+        var layers = {}
+        for (var d = 0; d < deviceIds.length; d++) {
+            var id = deviceIds[d]
+            var layer = layerOf[id]
+            if (!layers[layer]) layers[layer] = []
+            layers[layer].push(id)
+        }
+
+        // Assign positions: x by layer, y by position within layer
+        var positions = {}
+        var layerNums = Object.keys(layers).map(Number).sort(function (a, b) { return a - b })
+
+        for (var li = 0; li < layerNums.length; li++) {
+            var layerNum = layerNums[li]
+            var nodesInLayer = layers[layerNum]
+            var x = MARGIN_X + layerNum * LAYER_GAP
+
+            // Center the layer vertically
+            var totalHeight = 0
+            for (var n = 0; n < nodesInLayer.length; n++) {
+                var size = DEVICE_SIZES[circuitJSON.devices[nodesInLayer[n]].type] || DEFAULT_SIZE
+                totalHeight += size.height
+            }
+            totalHeight += (nodesInLayer.length - 1) * NODE_GAP
+
+            var startY = MARGIN_Y + Math.max(0, (400 - totalHeight) / 2)
+            var currentY = startY
+
+            for (var p = 0; p < nodesInLayer.length; p++) {
+                var nodeId = nodesInLayer[p]
+                var nodeSize = DEVICE_SIZES[circuitJSON.devices[nodeId].type] || DEFAULT_SIZE
+                positions[nodeId] = {
+                    x: Math.round(x),
+                    y: Math.round(currentY + nodeSize.height / 2)
+                }
+                currentY += nodeSize.height + NODE_GAP
+            }
+        }
+
+        return positions
+    } catch (err) {
+        console.warn('Circuit auto-layout failed, using default positions:', err)
+        return {}
+    }
+}

--- a/v1/src/simulator/src/synthesis/clientSynthesis.js
+++ b/v1/src/simulator/src/synthesis/clientSynthesis.js
@@ -1,0 +1,54 @@
+// Client-side synthesis — spawns a web worker for YoWASP Yosys
+
+var worker = null
+var requestId = 0
+
+export function synthesizeVerilog(verilogCode, onProgress) {
+    return new Promise((resolve, reject) => {
+        if (!worker) {
+            try {
+                worker = new Worker(new URL('./synthesisWorker.js', import.meta.url), { type: 'module' })
+            } catch (err) {
+                reject(new Error('Failed to create synthesis worker: ' + err.message))
+                return
+            }
+        }
+
+        var id = ++requestId
+
+        function handleMessage(e) {
+            if (e.data.id !== id) return
+
+            switch (e.data.type) {
+                case 'progress':
+                    if (onProgress) onProgress(e.data.message)
+                    break
+
+                case 'result':
+                    cleanup()
+                    resolve(e.data.data)
+                    break
+
+                case 'error':
+                    cleanup()
+                    reject(new Error(e.data.message))
+                    break
+            }
+        }
+
+        function handleError(err) {
+            cleanup()
+            reject(new Error('Synthesis worker error: ' + (err.message || 'Unknown error')))
+        }
+
+        function cleanup() {
+            worker.removeEventListener('message', handleMessage)
+            worker.removeEventListener('error', handleError)
+        }
+
+        worker.addEventListener('message', handleMessage)
+        worker.addEventListener('error', handleError)
+
+        worker.postMessage({ type: 'synthesize', code: verilogCode, id: id })
+    })
+}

--- a/v1/src/simulator/src/synthesis/clientSynthesis.js
+++ b/v1/src/simulator/src/synthesis/clientSynthesis.js
@@ -49,6 +49,11 @@ export function synthesizeVerilog(verilogCode, onProgress) {
         worker.addEventListener('message', handleMessage)
         worker.addEventListener('error', handleError)
 
-        worker.postMessage({ type: 'synthesize', code: verilogCode, id: id })
+        try {
+            worker.postMessage({ type: 'synthesize', code: verilogCode, id: id })
+        } catch (err) {
+            cleanup()
+            reject(new Error('Failed to send code to synthesis worker: ' + err.message))
+        }
     })
 }

--- a/v1/src/simulator/src/synthesis/clientSynthesis.js
+++ b/v1/src/simulator/src/synthesis/clientSynthesis.js
@@ -38,6 +38,8 @@ export function synthesizeVerilog(verilogCode, onProgress) {
 
         function handleError(err) {
             cleanup()
+            worker.terminate()
+            worker = null
             reject(new Error('Synthesis worker error: ' + (err.message || 'Unknown error')))
         }
 

--- a/v1/src/simulator/src/synthesis/synthesisWorker.js
+++ b/v1/src/simulator/src/synthesis/synthesisWorker.js
@@ -1,0 +1,43 @@
+// Web Worker — runs YoWASP Yosys in a background thread
+
+import { runYosys } from '@yowasp/yosys'
+import { yosys2digitaljs } from 'yosys2digitaljs/core'
+
+var silentPrint = () => {}
+var wasmReady = false
+
+self.onmessage = async function (e) {
+    var { type, code, id } = e.data
+    if (type !== 'synthesize') return
+
+    try {
+        if (!wasmReady) {
+            self.postMessage({ type: 'progress', message: 'Loading Yosys WASM engine...', id })
+            await runYosys([], {}, { print: silentPrint, printErr: silentPrint })
+            wasmReady = true
+        }
+
+        self.postMessage({ type: 'progress', message: 'Running Yosys synthesis...', id })
+        var result = await runYosys(
+            [
+                '-p',
+                'read_verilog input.v; setattr -mod -unset top; hierarchy -auto-top; proc; opt; memory -nomap; wreduce -memx; opt -full; write_json output.json',
+            ],
+            { 'input.v': code },
+            { print: silentPrint, printErr: silentPrint }
+        )
+
+        var jsonContent = result['output.json']
+        if (jsonContent instanceof Uint8Array) {
+            jsonContent = new TextDecoder().decode(jsonContent)
+        }
+        var yosysNetlist = JSON.parse(jsonContent)
+
+        self.postMessage({ type: 'progress', message: 'Converting netlist to circuit...', id })
+        var digitalJsCircuit = yosys2digitaljs(yosysNetlist)
+
+        self.postMessage({ type: 'result', data: digitalJsCircuit, id })
+    } catch (error) {
+        self.postMessage({ type: 'error', message: error.message || 'Synthesis failed', id })
+    }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,32 @@ import vuetify from "vite-plugin-vuetify";
 
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 
+function stripShebangPlugin() {
+  return {
+    name: "strip-shebang",
+    transform(code: string, id: string) {
+      if (id.includes("yosys2digitaljs") && code.startsWith("#!")) {
+        return { code: code.replace(/^#!.*/, ""), map: null };
+      }
+      return null;
+    },
+  };
+}
+
+function wasmMimePlugin() {
+  return {
+    name: "wasm-mime-type",
+    configureServer(server: any) {
+      server.middlewares.use((req: any, res: any, next: any) => {
+        if (req.url && req.url.endsWith(".wasm")) {
+          res.setHeader("Content-Type", "application/wasm");
+        }
+        next();
+      });
+    },
+  };
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(() => {
   const version = process.env.VITE_SIM_VERSION || "v0";
@@ -15,6 +41,8 @@ export default defineConfig(() => {
 
   return {
     plugins: [
+      stripShebangPlugin(),
+      wasmMimePlugin(),
       vue(),
       vuetify({ autoImport: true }),
       cssInjectedByJsPlugin(),
@@ -22,6 +50,9 @@ export default defineConfig(() => {
         strictMessage: false,
       }),
     ],
+    optimizeDeps: {
+      exclude: ["@yowasp/yosys", "vue"],
+    },
     resolve: {
       alias: {
         "#": fileURLToPath(new URL(`./${version}/src`, import.meta.url)),
@@ -46,6 +77,9 @@ export default defineConfig(() => {
     },
     server: {
       port: 4000,
+      watch: {
+        ignored: ["**/src-tauri/target/**"],
+      },
     },
     preview: {
       port: 4173,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,8 @@ function wasmMimePlugin() {
     name: "wasm-mime-type",
     configureServer(server: any) {
       server.middlewares.use((req: any, res: any, next: any) => {
-        if (req.url && req.url.endsWith(".wasm")) {
+        const pathname = (req.url || "").split("?")[0];
+        if (pathname.endsWith(".wasm")) {
           res.setHeader("Content-Type", "application/wasm");
         }
         next();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -52,6 +52,9 @@ export default defineConfig(() => {
       }),
     ],
     optimizeDeps: {
+      // Vue is excluded from pre-bundling: bundling its esm-bundler runtime
+      // alongside vuetify + vue-i18n triggers a runtime
+      // "init_runtime_dom_esm_bundler is not defined" ReferenceError in dev.
       exclude: ["@yowasp/yosys", "vue"],
     },
     resolve: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,8 @@ import vuetify from "vite-plugin-vuetify";
 import VueI18nPlugin from "@intlify/unplugin-vue-i18n/vite";
 import cssInjectedByJsPlugin from "vite-plugin-css-injected-by-js";
 
+const synthesisSpecs = ["v1/src/simulator/spec/synthesis.spec.js"];
+
 const createProjectConfig = (version: string) => ({
   plugins: [
     vue(),
@@ -48,8 +50,8 @@ const createProjectConfig = (version: string) => ({
 
     exclude:
       version === "src"
-        ? ["v0/**/*", "v1/**/*"]
-        : ["src/**/*", version === "v0" ? "v1/**/*" : "v0/**/*"],
+        ? ["v0/**/*", "v1/**/*", ...synthesisSpecs]
+        : ["src/**/*", version === "v0" ? "v1/**/*" : "v0/**/*", ...synthesisSpecs],
 
     setupFiles: [
       version === "src"
@@ -65,8 +67,16 @@ const createProjectConfig = (version: string) => ({
   },
 });
 
+const synthesisProject = {
+  test: {
+    name: "synthesis",
+    environment: "node" as const,
+    include: synthesisSpecs,
+  },
+};
+
 export default defineConfig({
   test: {
-    projects: [createProjectConfig("src"), createProjectConfig("v1")],
+    projects: [createProjectConfig("src"), createProjectConfig("v1"), synthesisProject],
   },
 });


### PR DESCRIPTION
Fixes #1058
Fixes #1059


### Describe the changes you have made in this PR -

This PR adds **client-side Verilog synthesis** to the v1 simulator so the Tauri desktop app can synthesize Verilog fully offline (no backend / no YosysJS server call).

**New files**
- `v1/src/simulator/src/synthesis/synthesisWorker.js`, a Web Worker that runs `@yowasp/yosys` (Yosys compiled to WASM) plus `yosys2digitaljs` to turn Verilog source into a DigitalJS circuit graph, off the main thread.
- `v1/src/simulator/src/synthesis/clientSynthesis.js`, spawns the worker (loaded via Vite's native `new URL(..., import.meta.url)` worker pattern), sends the Verilog input, and returns the synthesized circuit.
- `v1/src/simulator/src/synthesis/circuitLayout.js`, dependency-free auto-layout: `computeLayout()` does a topological layered placement (Kahn's algorithm) and `computePortLayout()` positions the subcircuit shell's input/output ports.
- `v1/src/simulator/spec/synthesis.spec.js`, unit tests for the layout logic.

**Modified files**
- `v1/src/simulator/src/Verilog2CV.js`, wires the client-side synthesis path into the existing Verilog-to-CircuitVerse flow using an `isTauri()` check.
- `vite.config.ts`, strips the `#!` shebang from `yosys2digitaljs` so it bundles cleanly, and sets the `application/wasm` MIME type on the dev server. (Vite bundles the worker and emits the WASM/resource assets automatically, so no manual copy step is needed.)
- `vitest.config.ts`, adds the `synthesis` test project.
- `package.json` / `package-lock.json`, add the `@yowasp/yosys` and `yosys2digitaljs` dependencies and the `test:synthesis` script.
- `v1/src/simulator/src/layoutMode.ts`, fixes an operator-precedence bug in the label-offset math (`x + typeof info[1] === "number" ? ...` always took the else branch).
- `v1/src/simulator/src/subcircuit.ts`, label-rendering adjustment for synthesized subcircuit shells.


### Screenshot of build -

<img width="1520" height="972" alt="Screenshot 2026-06-24 111330" src="https://github.com/user-attachments/assets/78f56166-4348-46e2-89f5-b2ceec4c4c8c" />

### Screenrecording -


https://github.com/user-attachments/assets/6f182443-d5f9-4bec-8db9-ceaaf189f02a



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

### Explain your implementation approach:

**What problem does this solve?**

Verilog synthesis in the simulator currently depends on a server-side Yosys call, so it does not work in the offline Tauri desktop build. Running Yosys (a large WASM binary) directly on the browser's main thread would block the event loop and freeze the UI while synthesis runs. The WASM binaries are also large, so they should not be committed to the repository.

**Alternative approaches I considered:**

- Running synthesis on the main thread : rejected, since it freezes the UI for the duration of synthesis.
- Shipping a server-side or bundled native Yosys : rejected, since it defeats the goal of fully offline desktop synthesis and adds a backend / native-build dependency.
- I initially bundled the worker with a standalone Rollup config, but now, project's bundler (Vite 8 / Rolldown) handles the worker and its WASM imports natively without any interfarence of esbuild, so I removed the extra config in favour of Vite's built-in worker support.

**Why I chose this implementation:**

I run synthesis in a dedicated Web Worker so the heavy Yosys WASM execution never blocks the main thread and the UI stays responsive. The worker is loaded with Vite's native worker pattern, `new Worker(new URL('./synthesisWorker.js', import.meta.url), { type: 'module' })`, so Vite automatically bundles the worker and emits the WASM/resource assets at build time. This means no separate build step and no large binaries committed to git: a contributor gets everything just by running `npm install` and `npm run tauri dev` for v1.

**Key components:**
- `synthesisWorker.js`: runs Yosys WASM + yosys2digitaljs in a worker.
- `clientSynthesis.js`: spawns the worker (via Vite's native worker URL), handles progress/result/error messages.
- `circuitLayout.js`: auto-places the synthesized circuit using a topological sort so gates flow left-to-right by dependency; `computePortLayout` positions the shell ports.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---



Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added circuit auto-layout for device placement and port geometry.
  * Added simulator Verilog/Yosys synthesis with live progress updates, running in the browser or on desktop depending on platform.
* **Bug Fixes**
  * Improved synthesis error handling and user-facing messaging across web and desktop.
  * Fixed subcircuit label vertical alignment at exact boundary positions.
* **Tests**
  * Added dedicated synthesis spec coverage and updated test scripts/config to run synthesis tests separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->