### PR TITLE
fix: correct user menu close icon and washed-out hover state

### DIFF
--- a/src/components/Navbar/User/UserMenu.vue
+++ b/src/components/Navbar/User/UserMenu.vue
@@ -17,7 +17,7 @@
             variant="text"
             color="white"
           >
-            <v-icon icon="mdi-arrow-right" size="large"></v-icon>
+            <v-icon icon="mdi-close" size="large"></v-icon>
           </v-btn>
         </div>
 

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -1951,9 +1951,8 @@ canvas {
 }
 .dialogClose:hover {
     font-weight: bold;
-    background: white;
-    opacity: 0.5;
-    color: black;
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--primary-btn-hov);
 }
 
 .dialogHeader {

--- a/v1/src/components/Navbar/User/UserMenu.vue
+++ b/v1/src/components/Navbar/User/UserMenu.vue
@@ -17,7 +17,7 @@
             variant="text"
             color="white"
           >
-            <v-icon icon="mdi-arrow-right" size="large"></v-icon>
+            <v-icon icon="mdi-close" size="large"></v-icon>
           </v-btn>
         </div>
 

--- a/v1/src/styles/css/main.stylesheet.css
+++ b/v1/src/styles/css/main.stylesheet.css
@@ -1941,9 +1941,8 @@ canvas {
 }
 .dialogClose:hover {
     font-weight: bold;
-    background: white;
-    opacity: 0.5;
-    color: black;
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--primary-btn-hov);
 }
 
 .dialogHeader {


### PR DESCRIPTION
Fixes #1121

#### Describe the changes you have made in this PR -
- Changed the close button icon in the user menu drawer (`src/components/Navbar/User/UserMenu.vue`) from `mdi-arrow-right` to `mdi-close`, matching the close icon convention used by every other dialog in the codebase.
- Fixed the shared `.dialogClose:hover` rule in `src/styles/css/main.stylesheet.css`. It previously applied `opacity: 0.5` to the whole button, which washed both the background fill and the icon color into a flat grey blob with no real visual feedback. Replaced it with a translucent `rgba(255, 255, 255, 0.15)` highlight background and a distinct icon color change on hover, reusing the existing `--primary-btn-hov` theme variable. Since `.dialogClose` is shared across all dialog close buttons in the app (SaveImage, ExportVerilog, ApplyThemes, etc.), this also fixes the same washed-out hover everywhere else it's used.

### Screenshots of the UI changes (If any) -
Before:
1. Arrow Icon
<img width="1580" height="785" alt="image" src="https://github.com/user-attachments/assets/462bf1e5-6b66-41d1-9c2e-0367cd810bd1" />

2. Hover didn't changed the state.
<img width="1567" height="766" alt="image" src="https://github.com/user-attachments/assets/1fc749f8-9ebb-4717-9739-e999cbfa05d4" />

Fixed:

1. X icon 
<img width="1776" height="855" alt="image" src="https://github.com/user-attachments/assets/ac5922de-983e-42fd-bd0c-433244e2486a" />

2. On hover the state changes
<img width="1787" height="863" alt="image" src="https://github.com/user-attachments/assets/7b4fb190-a2de-4e3e-83ef-1d46504a342d" />


---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The bug had two separate causes. First, the drawer's close button used the wrong Material Design Icon — `mdi-arrow-right` instead of `mdi-close` — which was just a one-line icon swap to match the convention used everywhere else in the codebase. Second, the shared `.dialogClose:hover` CSS rule set `opacity: 0.5` on the entire button element, which dims the background fill and the icon's color together — so instead of a visible, legible hover state, you just get a faded grey shape with no real contrast change. I replaced that with a translucent background overlay plus a distinct color change on the icon itself, reusing the `--primary-btn-hov` CSS variable already defined in the theme, so hovering now gives real, visible feedback. Because `.dialogClose` is a shared class used by every dialog box in the app, this single CSS fix applies consistently everywhere, not just in the user menu drawer. I considered scoping the fix only to this one button instead of the shared class, but that would have left the same bug present in every other dialog, so fixing the shared rule was the more correct and consistent choice.


---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the user drawer close button to use a standard close icon for clearer intent.
  * Refined dialog close hover styling with improved color contrast and a consistent semi-transparent background.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->