### PR TITLE
refactor: clear setInterval on unmount in PropertiesPanelMobile.vue

### DIFF
--- a/src/components/Panels/PropertiesPanel/PropertiesPanelMobile.vue
+++ b/src/components/Panels/PropertiesPanel/PropertiesPanelMobile.vue
@@ -141,7 +141,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRaw, onMounted, computed } from 'vue'
+import { toRaw, onMounted, onUnmounted, computed } from 'vue'
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore'
 import ProjectProperty from './ModuleProperty/ProjectProperty/ProjectProperty.vue'
 import ElementProperty from './ModuleProperty/ElementProperty/ElementProperty.vue'
@@ -170,8 +170,17 @@ watch(
     }
 )
 
+let propertiesPanelInterval: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
   // checks for which type of properties panel to show
-  setInterval(showPropertiesPanel, 100)
+  propertiesPanelInterval = setInterval(showPropertiesPanel, 100)
+})
+
+onUnmounted(() => {
+  if (propertiesPanelInterval) {
+    clearInterval(propertiesPanelInterval)
+    propertiesPanelInterval = null
+  }
 })
 </script>

--- a/v1/src/components/Panels/PropertiesPanel/PropertiesPanelMobile.vue
+++ b/v1/src/components/Panels/PropertiesPanel/PropertiesPanelMobile.vue
@@ -141,7 +141,7 @@
 </template>
 
 <script lang="ts" setup>
-import { toRaw, onMounted, computed } from 'vue'
+import { toRaw, onMounted, onUnmounted, computed } from 'vue'
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore'
 import ProjectProperty from './ModuleProperty/ProjectProperty/ProjectProperty.vue'
 import ElementProperty from './ModuleProperty/ElementProperty/ElementProperty.vue'
@@ -170,8 +170,17 @@ watch(
     }
 )
 
+let propertiesPanelInterval: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
   // checks for which type of properties panel to show
-  setInterval(showPropertiesPanel, 100)
+  propertiesPanelInterval = setInterval(showPropertiesPanel, 100)
+})
+
+onUnmounted(() => {
+  if (propertiesPanelInterval) {
+    clearInterval(propertiesPanelInterval)
+    propertiesPanelInterval = null
+  }
 })
 </script>


### PR DESCRIPTION
## Description
`PropertiesPanelMobile.vue` was using `setInterval(showPropertiesPanel, 100)` inside `onMounted` without ever clearing it. This causes the interval to keep running indefinitely even after the component unmounts, and creates a new overlapping interval each time it remounts — a memory/performance leak.

## Changes
- Store the interval ID in a variable
- Clear it in `onUnmounted`

## Testing
Tested locally on mobile viewport — properties panel still updates correctly when selecting elements, layout mode, and project properties. No regressions observed.

Relates to #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile properties panel behavior by stopping a background update timer when the panel is closed or destroyed.
  * Prevents unnecessary activity after navigating away, helping avoid lingering updates and improving app stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->