### PR TITLE
fix(verilog): TflipFlop ignores pre input on async reset

### DIFF
--- a/src/simulator/src/sequential/TflipFlop.js
+++ b/src/simulator/src/sequential/TflipFlop.js
@@ -146,17 +146,17 @@ export default class TflipFlop extends CircuitElement {
         module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);
           parameter WIDTH = 1;
           output reg [WIDTH-1:0] q, q_inv;
-          input clk, a_rst, pre, en;
-          input [WIDTH-1:0] t;
-        
+          input clk, a_rst, en;
+          input [WIDTH-1:0] t, pre;
+
           always @ (posedge clk or posedge a_rst)
             if (a_rst) begin
-              q <= 'b0;
-              q_inv <= 'b1;
+              q <= pre;
+              q_inv <= ~pre;
             end else if (en == 0) ;
             else if (t) begin
               q <= q ^ t;
-              q_inv <= ~q ^ t;
+              q_inv <= ~(q ^ t);
             end
         endmodule
         `

--- a/v1/src/simulator/src/sequential/TflipFlop.js
+++ b/v1/src/simulator/src/sequential/TflipFlop.js
@@ -146,17 +146,17 @@ export default class TflipFlop extends CircuitElement {
         module TflipFlop(q, q_inv, clk, t, a_rst, pre, en);
           parameter WIDTH = 1;
           output reg [WIDTH-1:0] q, q_inv;
-          input clk, a_rst, pre, en;
-          input [WIDTH-1:0] t;
-        
+          input clk, a_rst, en;
+          input [WIDTH-1:0] t, pre;
+
           always @ (posedge clk or posedge a_rst)
             if (a_rst) begin
-              q <= 'b0;
-              q_inv <= 'b1;
+              q <= pre;
+              q_inv <= ~pre;
             end else if (en == 0) ;
             else if (t) begin
               q <= q ^ t;
-              q_inv <= ~q ^ t;
+              q_inv <= ~(q ^ t);
             end
         endmodule
         `


### PR DESCRIPTION
Fixes #1104

Describe the changes you have made in this PR

While investigating this issue, I found that "TflipFlop" handles asynchronous reset differently from the other flip-flop implementations.

Currently, it always assigns "q" to "'b0" and "q_inv" to "'b1" during reset, ignoring the "pre" input. "DflipFlop" already resets using "pre" the same way ("q <= pre; q_inv <= ~pre;"), so this brings "TflipFlop" in line with that. ("JKFlipFlop" and "SRFlipFlop" use a different, synchronous reset style where "pre" is a boolean condition rather than a bus assigned directly to "q", so they aren't directly comparable here.) Since "pre" is declared but never used in "TflipFlop", synthesis tools may optimize it away, which is the issue being addressed.

To fix this, I updated "pre" to a "[WIDTH-1:0]" bus and used it in the reset logic:

- "q <= pre;"
- "q_inv <= ~pre;"

This follows the same implementation pattern already used in "DflipFlop", keeping the behavior consistent across all flip-flop modules.

I also updated:

q_inv <= ~q ^ t;

to

q_inv <= ~(q ^ t);

This does not change the functionality but makes the intended logic more explicit and easier to read.

The same changes were applied to both:

- "src/simulator/src/sequential/TflipFlop.js"
- "v1/simulator/src/sequential/TflipFlop.js"

to keep both implementations synchronized.

Screenshots of the UI changes (If any)

N/A – This change only affects Verilog generation and does not introduce any UI changes.

---

Checklist before requesting a review

- [x] I have added a proper PR title and linked the related issue.
- [x] I have performed a self-review of my code.
- [x] I understand the changes made and can explain the implementation.
- [x] I have considered potential edge cases.
- [ ] If this is a core feature, I have added appropriate tests.
- [x] My code follows the project's coding style and conventions.
