### PR TITLE
fix(v1): adjust top position of panels dynamically on tabs bar height…

### DIFF
--- a/v1/src/components/Extra.vue
+++ b/v1/src/components/Extra.vue
@@ -11,9 +11,12 @@
     <ExportVerilog />
     <!-- --------------------------------------------------------------------------------------------- -->
 
-    <!-- --------------------------------------------------------------------------------------------- -->
-    <!-- Circuit Elements Panel -->
-    <ElementsPanel v-if="!simulatorMobileStore.showMobileView && !simulatorMobileStore.isVerilog"/>
+    <div class="simulator-workspace">
+        <QuickButton v-if="!simulatorMobileStore.showMobileView" />
+
+        <!-- --------------------------------------------------------------------------------------------- -->
+        <!-- Circuit Elements Panel -->
+        <ElementsPanel v-if="!simulatorMobileStore.showMobileView && !simulatorMobileStore.isVerilog"/>
     <!-- --------------------------------------------------------------------------------------------- -->
 
     <!-- --------------------------------------------------------------------------------------------- -->
@@ -239,11 +242,13 @@
         <i class="fa-solid fa-sliders"></i>
     </v-btn>
 
-    <ElementsPanelMobile v-if="simulatorMobileStore.showMobileView" />
-    <PropertiesPanelMobile v-if="simulatorMobileStore.showMobileView" />
+        <ElementsPanelMobile v-if="simulatorMobileStore.showMobileView" />
+        <PropertiesPanelMobile v-if="simulatorMobileStore.showMobileView" />
+    </div>
 </template>
 
 <script lang="ts" setup>
+import QuickButton from './Navbar/QuickButton/QuickButton.vue'
 import VerilogEditorPanel from './Panels/VerilogEditorPanel/VerilogEditorPanel.vue'
 import VerilogEditorPanelMobile from './Panels/VerilogEditorPanel/VerilogEditorPanelMobile.vue'
 import ElementsPanel from './Panels/ElementsPanel/ElementsPanel.vue'
@@ -308,6 +313,13 @@ const propertiesBtnClick = () => {
 </script>
 
 <style scoped>
+.simulator-workspace {
+    position: relative;
+    width: 100%;
+    flex: 1;
+    min-height: 0;
+}
+
 .cir-ele-btn, .cir-verilog-btn {
     position: absolute;
     right: 1.5rem;

--- a/v1/src/components/Navbar/Navbar.vue
+++ b/v1/src/components/Navbar/Navbar.vue
@@ -18,11 +18,9 @@
             <UserMenu class="useMenuBtn" />
         </div>
     </nav>
-    <QuickButton v-if="!simulatorMobileStore.showMobileView" />
 </template>
 
 <script lang="ts" setup>
-import QuickButton from '@/Navbar/QuickButton/QuickButton.vue'
 import NavbarLinks from '@/Navbar/NavbarLinks/NavbarLinks.vue'
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore'
 

--- a/v1/src/components/Navbar/QuickButton/QuickButton.vue
+++ b/v1/src/components/Navbar/QuickButton/QuickButton.vue
@@ -124,7 +124,7 @@ function dragover(): void {
     position: absolute;
     width: 400px;
     height: 33px;
-    top: 90px;
+    top: 10px;
     right: 280px;
     border-radius: 7px;
     z-index: 100;

--- a/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
+++ b/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
@@ -88,7 +88,7 @@ function getImgUrl(elementName: string) {
   width: 220px;
   font: inherit;
   display: none;
-  top: 90px;
+  top: 10px;
   left: 10px;
 }
 </style>

--- a/v1/src/pages/simulator.vue
+++ b/v1/src/pages/simulator.vue
@@ -1,7 +1,11 @@
 <template>
-    <Navbar />
+    <div class="simulator-layout">
+        <Navbar />
+        <div class="simulator-extra">
+            <Extra />
+        </div>
+    </div>
     <ContextMenu />
-    <Extra />
     <Helper />
 </template>
 
@@ -25,3 +29,21 @@ onMounted(() => {
     setupSimulator()
 })
 </script>
+
+<style scoped>
+.simulator-layout {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    width: 100vw;
+    overflow: hidden;
+}
+
+.simulator-extra {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+    position: relative;
+}
+</style>

--- a/v1/src/styles/css/5-layout/simulator.scss
+++ b/v1/src/styles/css/5-layout/simulator.scss
@@ -40,7 +40,7 @@
 
 #restrictedElementsDiv {
     position: absolute;
-    top: 90px;
+    top: 10px;
     right: 10px;
     z-index: 100;
     width: 200px;

--- a/v1/src/styles/css/UX.css
+++ b/v1/src/styles/css/UX.css
@@ -395,7 +395,7 @@ html {
 
 #restrictedElementsDiv {
     position: absolute;
-    top: 90px;
+    top: 10px;
     right: 10px;
     z-index: 100;
     width: 200px;

--- a/v1/src/styles/css/main.stylesheet.css
+++ b/v1/src/styles/css/main.stylesheet.css
@@ -254,7 +254,7 @@ input[type='text']:focus {
     border-radius: 5px;
     z-index: 70;
     transition: background 0.5s ease-out;
-    position: fixed;
+    position: absolute;
 }
 
 @supports (backdrop-filter: blur()) {
@@ -358,7 +358,7 @@ input[type='text']:focus {
 .ce-panel {
     font: inherit;
     width: 240px;
-    top: 90px;
+    top: 10px;
     left: 10px;
 }
 
@@ -657,7 +657,7 @@ div.icon img {
 .moduleProperty {
     font: inherit;
     width: 250px;
-    top: 90px;
+    top: 10px;
     right: 10px;
 }
 
@@ -665,10 +665,10 @@ div.icon img {
     border-radius: 5px;
     z-index: 70;
     transition: background 0.5s ease-out;
-    position: fixed;
+    position: absolute;
     cursor: pointer;
     left: 300px;
-    top: 90px;
+    top: 10px;
 }
 
 .timing-diagram-panel .panel-header {
@@ -883,7 +883,7 @@ div.icon img {
     width: 220px;
     font: inherit;
     display: none;
-    top: 90px;
+    top: 10px;
     right: 300px;
 }
 
@@ -1101,7 +1101,7 @@ input:checked + .slider:before {
 #layoutDialog {
     /* display: none; */
     right: 10px;
-    top: 90px;
+    top: 10px;
     width: 220px;
 }
 


### PR DESCRIPTION
… change

Fixes #1149 

#### Describe the changes you have made in this PR - 
1.Added a ResizeObserver in TabsBar.vue that observes the height of the #tabsBar element and sets a CSS custom property --tabs-height on document.documentElement.
2. Updated the top positioning of all top-aligned panels (.ce-panel, .moduleProperty, .layoutElementPanel, #verilogEditorPanel, #layoutDialog), timing diagram button (.timing-diagram-panel), and quick buttons toolbar (.quick-btn) to top: calc(var(--tabs-height, 30px) + 60px);.
3. This ensures that when the tabs bar expands or wraps onto multiple rows, all panels and toolbars dynamically shift down and do not overlap.


### Screenshots of the UI changes (If any) -
Before changes , video clip of v0
[Screencast From 2026-07-20 10-43-17.webm](https://github.com/user-attachments/assets/26a7d0d9-6674-4794-af4e-ebdd179b015b)


Video clip , after changes in v1 only 
[Screencast From 2026-07-21 19-09-06.webm](https://github.com/user-attachments/assets/ea024fb5-5025-4ac1-b105-b33de3acfc8b)


## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Describe in your own words:
What problem does your code solve?: It solves the issue where side panels, toolbars, and buttons overlap with the tabs bar when there are multiple rows of tabs.

What alternative approaches did you consider?: Hardcoding static top offsets or adding CSS toggle classes, but dynamic CSS variables via ResizeObserver handle any height variation smoothly.

Why did you choose this specific implementation?: Using ResizeObserver in TabsBar.vue dynamically detects any height changes (adding tabs, toggling height, or window resizing) and updates --tabs-height in real-time.

What are the key functions/components and what do they do?: TabsBar.vue observes #tabsBar height using ResizeObserver and sets --tabs-height, while CSS stylesheets use calc(var(--tabs-height, 30px) + 60px) for panel positions.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions
- [x] I allowed edits from maintainers


Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repositioned simulator panels and controls closer to the top of the workspace for improved accessibility.
  * Improved panel placement and sizing within the simulator layout.

* **Refactor**
  * Organized simulator controls and panels within a dedicated workspace layout.
  * Moved the quick-access control out of the navigation bar and into the simulator workspace.
  * Improved responsive handling for mobile and desktop simulator views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->