### PR TITLE
style(): reposition testbench panel and report issue button in v0

### DIFF
--- a/src/components/ReportIssue/ReportIssueButton.vue
+++ b/src/components/ReportIssue/ReportIssueButton.vue
@@ -5,7 +5,7 @@
             class="btn btn-primary text-light"
             data-toggle="modal"
             data-target=".issue"
-            :style="{ bottom: simulatorMobileStore.showElementsPanel ? '250px' : '120px' }"
+            :style="reportButtonStyle"
             @click="openReportingModal"
         >
             <span class="fa fa-bug"></span>&nbsp;&nbsp;{{
@@ -17,8 +17,18 @@
 
 <script lang="ts" setup>
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore';
+import { computed } from 'vue';
 
 const simulatorMobileStore = useSimulatorMobileStore();
+
+const reportButtonStyle = computed(() => {
+    if (simulatorMobileStore.showMobileView) {
+        return {
+            bottom: simulatorMobileStore.showElementsPanel ? '250px' : '120px',
+        };
+    }
+    return { top: '660px', bottom: 'auto' };
+});
 
 const emit = defineEmits(['openReportModal'])
 

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -690,8 +690,8 @@ div.icon img {
     transition: background 0.5s ease-out;
     position: fixed;
     cursor: pointer;
-    left: 10px;
-    top: 470px;
+    right: 10px;
+top: 550px;
 }
 
 .testbench-manual-panel .panel-header {

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -691,7 +691,7 @@ div.icon img {
     position: fixed;
     cursor: pointer;
     right: 10px;
-top: 550px;
+    top: 550px;
 }
 
 .testbench-manual-panel .panel-header {


### PR DESCRIPTION
Fixes #1154 

Describe the changes you have made in this PR -

This PR ports the fix from [CircuitVerse/cv-frontend-vue#1139](https://github.com/CircuitVerse/cv-frontend-vue/pull/1139) (already merged in v1) to v0. That PR repositioned the report-issue button and the testbench panel to fix a visual overlap between the two elements. This PR applies the equivalent positioning changes to v0:

ReportIssueButton.vue: replaced the inline conditional :style binding with a reportButtonStyle computed property that adjusts the button's position based on mobile view and elements-panel state.
main.stylesheet.css: updated .testbench-manual-panel's position from left: 10px; top: 470px; to right: 10px; top: 550px;, matching v1's fix.
Screenshots of the UI changes (If any) -
<img width="1470" height="876" alt="Screenshot 2026-07-22 at 1 42 29 AM" src="https://github.com/user-attachments/assets/07343d27-45d5-4cc7-9727-329f535dd113" />



Code Understanding and AI Usage

Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?

- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

Explain your implementation approach:
I identified that #1139 fixed an overlap between the report-issue button and the testbench panel in v1, but the same fix hadn't been ported to v0. I located the v0 equivalents of the changed files (v0/src/components/ReportIssue/ReportIssueButton.vue and v0/src/styles/css/main.stylesheet.css), compared them against the v1 diff, and applied the same logic: extracting the button's position into a computed property that reacts to mobile-view/elements-panel state, and updating the testbench panel's fixed position values to match. I verified the change by running the app locally and confirming the two elements no longer overlap.

Checklist before requesting a review
 - [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the report issue button’s positioning across mobile views and when the elements panel is shown/hidden.
  * Repositioned the testbench manual panel to use right anchoring and a lower vertical offset for better on-screen alignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->