### PR TITLE
fix: guard Tauri-only event listeners with isTauri() check

### DIFF
--- a/src/simulator/src/listeners.js
+++ b/src/simulator/src/listeners.js
@@ -36,6 +36,7 @@ import { verilogModeGet } from './Verilog2CV'
 import { setupTimingListeners } from './plotArea'
 import logixFunction from './data'
 import { listen } from '@tauri-apps/api/event'
+import { isTauri } from '@tauri-apps/api/core'
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore'
 import { toRefs } from 'vue'
 import { fitToSelection } from './canvasApi'
@@ -825,91 +826,97 @@ function zoomSliderListeners() {
 }
 
 // Desktop App Listeners
+// These rely on Tauri's IPC bridge (window.__TAURI_INTERNALS__), which only
+// exists inside the Tauri desktop shell. Registering them on the plain web
+// build throws "Cannot read properties of undefined (reading 'transformCallback')"
+// so they must only run when actually inside Tauri.
 
-listen('new-project', () => {
-    logixFunction.newProject();
-});
+if (isTauri()) {
+    listen('new-project', () => {
+        logixFunction.newProject();
+    });
 
-listen('save-online', () => {
-    logixFunction.save();
-});
+    listen('save-online', () => {
+        logixFunction.save();
+    });
 
-listen('save-offline', () => {
-    logixFunction.saveOffline();
-});
+    listen('save-offline', () => {
+        logixFunction.saveOffline();
+    });
 
-listen('open-offline', () => {
-    logixFunction.createOpenLocalPrompt();
-});
+    listen('open-offline', () => {
+        logixFunction.createOpenLocalPrompt();
+    });
 
-listen('export', () => {
-    logixFunction.ExportProject();
-});
+    listen('export', () => {
+        logixFunction.ExportProject();
+    });
 
-listen('import', () => {
-    logixFunction.ImportProject();
-});
+    listen('import', () => {
+        logixFunction.ImportProject();
+    });
 
-listen('recover', () => {
-    logixFunction.recoverProject();
-});
+    listen('recover', () => {
+        logixFunction.recoverProject();
+    });
 
-listen('clear', () => {
-    logixFunction.clearProject();
-});
+    listen('clear', () => {
+        logixFunction.clearProject();
+    });
 
-listen('preview-circuit', () => {
-    logixFunction.fullViewOption();
-});
+    listen('preview-circuit', () => {
+        logixFunction.fullViewOption();
+    });
 
-listen('new-circuit', () => {
-    logixFunction.createNewCircuitScope();
-});
+    listen('new-circuit', () => {
+        logixFunction.createNewCircuitScope();
+    });
 
-listen('new-verilog-module', () => {
-    logixFunction.newVerilogModule();
-});
+    listen('new-verilog-module', () => {
+        logixFunction.newVerilogModule();
+    });
 
-listen('insert-sub-circuit', () => {
-    logixFunction.createSubCircuitPrompt();
-});
+    listen('insert-sub-circuit', () => {
+        logixFunction.createSubCircuitPrompt();
+    });
 
-listen('combinational-analysis', () => {
-    logixFunction.createCombinationalAnalysisPrompt();
-});
+    listen('combinational-analysis', () => {
+        logixFunction.createCombinationalAnalysisPrompt();
+    });
 
-listen('hex-bin-dec', () => {
-    logixFunction.bitconverter();
-});
+    listen('hex-bin-dec', () => {
+        logixFunction.bitconverter();
+    });
 
-listen('download-image', () => {
-    logixFunction.createSaveAsImgPrompt();
-});
+    listen('download-image', () => {
+        logixFunction.createSaveAsImgPrompt();
+    });
 
-listen('themes', () => {
-    logixFunction.colorThemes();
-});
+    listen('themes', () => {
+        logixFunction.colorThemes();
+    });
 
-listen('custom-shortcut', () => {
-    logixFunction.customShortcut();
-});
+    listen('custom-shortcut', () => {
+        logixFunction.customShortcut();
+    });
 
-listen('export-verilog', () => {
-    logixFunction.generateVerilog();
-});
+    listen('export-verilog', () => {
+        logixFunction.generateVerilog();
+    });
 
-listen('tutorial', () => {
-    logixFunction.showTourGuide();
-});
+    listen('tutorial', () => {
+        logixFunction.showTourGuide();
+    });
 
-listen('user-manual', () => {
-    logixFunction.showUserManual();
-});
+    listen('user-manual', () => {
+        logixFunction.showUserManual();
+    });
 
-listen('learn-digital-circuit', () => {
-    logixFunction.showDigitalCircuit();
-});
+    listen('learn-digital-circuit', () => {
+        logixFunction.showDigitalCircuit();
+    });
 
-listen('discussion-forum', () => {
-    logixFunction.showDiscussionForum();
-});
+    listen('discussion-forum', () => {
+        logixFunction.showDiscussionForum();
+    });
+}

--- a/v1/src/simulator/src/listeners.js
+++ b/v1/src/simulator/src/listeners.js
@@ -36,6 +36,7 @@ import { verilogModeGet } from './Verilog2CV'
 import { setupTimingListeners } from './plotArea'
 import logixFunction from './data'
 import { listen } from '@tauri-apps/api/event'
+import { isTauri } from '@tauri-apps/api/core'
 import { useSimulatorMobileStore } from '#/store/simulatorMobileStore'
 import { toRefs } from 'vue'
 
@@ -789,91 +790,97 @@ function handleZoom (direction) {
   }
 
 // Desktop App Listeners
+// These rely on Tauri's IPC bridge (window.__TAURI_INTERNALS__), which only
+// exists inside the Tauri desktop shell. Registering them on the plain web
+// build throws "Cannot read properties of undefined (reading 'transformCallback')"
+// so they must only run when actually inside Tauri.
 
-listen('new-project', () => {
-    logixFunction.newProject();
-});
+if (isTauri()) {
+    listen('new-project', () => {
+        logixFunction.newProject();
+    });
 
-listen('save-online', () => {
-    logixFunction.save();
-});
+    listen('save-online', () => {
+        logixFunction.save();
+    });
 
-listen('save-offline', () => {
-    logixFunction.saveOffline();
-});
+    listen('save-offline', () => {
+        logixFunction.saveOffline();
+    });
 
-listen('open-offline', () => {
-    logixFunction.createOpenLocalPrompt();
-});
+    listen('open-offline', () => {
+        logixFunction.createOpenLocalPrompt();
+    });
 
-listen('export', () => {
-    logixFunction.ExportProject();
-});
+    listen('export', () => {
+        logixFunction.ExportProject();
+    });
 
-listen('import', () => {
-    logixFunction.ImportProject();
-});
+    listen('import', () => {
+        logixFunction.ImportProject();
+    });
 
-listen('recover', () => {
-    logixFunction.recoverProject();
-});
+    listen('recover', () => {
+        logixFunction.recoverProject();
+    });
 
-listen('clear', () => {
-    logixFunction.clearProject();
-});
+    listen('clear', () => {
+        logixFunction.clearProject();
+    });
 
-listen('preview-circuit', () => {
-    logixFunction.fullViewOption();
-});
+    listen('preview-circuit', () => {
+        logixFunction.fullViewOption();
+    });
 
-listen('new-circuit', () => {
-    logixFunction.createNewCircuitScope();
-});
+    listen('new-circuit', () => {
+        logixFunction.createNewCircuitScope();
+    });
 
-listen('new-verilog-module', () => {
-    logixFunction.newVerilogModule();
-});
+    listen('new-verilog-module', () => {
+        logixFunction.newVerilogModule();
+    });
 
-listen('insert-sub-circuit', () => {
-    logixFunction.createSubCircuitPrompt();
-});
+    listen('insert-sub-circuit', () => {
+        logixFunction.createSubCircuitPrompt();
+    });
 
-listen('combinational-analysis', () => {
-    logixFunction.createCombinationalAnalysisPrompt();
-});
+    listen('combinational-analysis', () => {
+        logixFunction.createCombinationalAnalysisPrompt();
+    });
 
-listen('hex-bin-dec', () => {
-    logixFunction.bitconverter();
-});
+    listen('hex-bin-dec', () => {
+        logixFunction.bitconverter();
+    });
 
-listen('download-image', () => {
-    logixFunction.createSaveAsImgPrompt();
-});
+    listen('download-image', () => {
+        logixFunction.createSaveAsImgPrompt();
+    });
 
-listen('themes', () => {
-    logixFunction.colorThemes();
-});
+    listen('themes', () => {
+        logixFunction.colorThemes();
+    });
 
-listen('custom-shortcut', () => {
-    logixFunction.customShortcut();
-});
+    listen('custom-shortcut', () => {
+        logixFunction.customShortcut();
+    });
 
-listen('export-verilog', () => {
-    logixFunction.generateVerilog();
-});
+    listen('export-verilog', () => {
+        logixFunction.generateVerilog();
+    });
 
-listen('tutorial', () => {
-    logixFunction.showTourGuide();
-});
+    listen('tutorial', () => {
+        logixFunction.showTourGuide();
+    });
 
-listen('user-manual', () => {
-    logixFunction.showUserManual();
-});
+    listen('user-manual', () => {
+        logixFunction.showUserManual();
+    });
 
-listen('learn-digital-circuit', () => {
-    logixFunction.showDigitalCircuit();
-});
+    listen('learn-digital-circuit', () => {
+        logixFunction.showDigitalCircuit();
+    });
 
-listen('discussion-forum', () => {
-    logixFunction.showDiscussionForum();
-});
+    listen('discussion-forum', () => {
+        logixFunction.showDiscussionForum();
+    });
+}


### PR DESCRIPTION
Fixes #950

#### Describe the changes you have made in this PR -

The "Desktop App Listeners" block in `listeners.js` (both `src/simulator/src/listeners.js` and `v1/src/simulator/src/listeners.js`) called Tauri's `listen()` API unconditionally at module load time, registering ~22 listeners for menu actions like New Project, Save, Export, Tutorial, etc.

`listen()` depends on `window.__TAURI_INTERNALS__`, which only exists inside the Tauri desktop shell. On plain web builds (v0 dev server, v1 dev server, and embedded widgets such as those on docs.circuitverse.org), this global is undefined, so every `listen()` call threw:

Since `listen()` returns a Promise that wasn't awaited or caught, each call produced an unhandled promise rejection — one per listener, per widget instance, matching the reproduction steps in this issue (errors appearing at consecutive line numbers).

**Fix:** Wrapped the entire Desktop App Listeners block in `if (isTauri()) { ... }` in both files, so these listeners only register when actually running inside the Tauri shell. This follows the same guard pattern already used elsewhere in the codebase (`plotArea.js`, `Verilog2CV.js`), rather than introducing a new detection mechanism.

#### Screenshots of the UI changes (If any) -

No UI changes — this is a runtime error fix with no visual impact. Console screenshots showing the error before/after the fix are included in the issue thread (#950).

---
## Code Understanding and AI Usage
**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The root problem was that Tauri's `listen()` API was being invoked on every platform, but it only functions inside the Tauri desktop shell, since it relies on Tauri's internal IPC bridge (`window.__TAURI_INTERNALS__`). On web builds — the v0/v1 dev servers and embedded simulator widgets — that bridge doesn't exist, so every `listen()` call threw an unhandled promise rejection.

I considered wrapping each individual `listen()` call in a try/catch, but rejected that approach since it would just suppress the error without addressing why the API call was happening in the first place, and would still attempt to call something structurally incompatible with the environment.

Instead, I used `isTauri()` from `@tauri-apps/api/core`, which is the existing convention this codebase already uses to detect the runtime (see `plotArea.js` and `Verilog2CV.js`). I wrapped the full "Desktop App Listeners" block — all `listen()` registrations for menu actions like New Project, Save, Export, Import, Tutorial, etc. — in `if (isTauri())`, so they're skipped entirely on web and only run in the actual desktop app.

I tested this by running both the v0 and v1 dev servers locally and confirming the browser console no longer shows the `transformCallback` error, and by running `npm run tauri dev` to confirm the desktop menu actions still fire correctly (since `isTauri()` returns `true` there).

---
## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] I can explain the purpose of every function, class, and logic block I added
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---
Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for web builds by preventing desktop-only integrations from loading outside the Tauri app.
  * Prevented errors caused by unavailable desktop services when using the simulator in a browser.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->