### PR TITLE
fix: clear setInterval on unmount in PropertiesPanel.vue (#469)

### DIFF
--- a/src/components/Panels/PropertiesPanel/PropertiesPanel.spec.ts
+++ b/src/components/Panels/PropertiesPanel/PropertiesPanel.spec.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import PropertiesPanel from "./PropertiesPanel.vue";
+
+vi.mock("#/components/Panels/PropertiesPanel/ModuleProperty/ModuleProperty.vue", () => ({
+  default: { name: "ModuleProperty", template: "<div />" },
+}));
+vi.mock("#/components/Panels/PropertiesPanel/LayoutProperty/LayoutProperty.vue", () => ({
+  default: { name: "LayoutProperty", template: "<div />" },
+}));
+
+vi.mock("codemirror", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    fromTextArea: vi.fn(() => ({ setValue: () => {} })),
+  };
+});
+
+vi.mock("codemirror-editor-vue3", () => ({
+  defineSimpleMode: vi.fn(),
+}));
+
+describe("PropertiesPanel.vue", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  test("clears its polling interval on unmount instead of leaking it", () => {
+    const wrapper = mount(PropertiesPanel);
+
+    const timerCountAfterMount = vi.getTimerCount();
+    expect(timerCountAfterMount).toBeGreaterThan(0);
+
+    wrapper.unmount();
+
+    expect(vi.getTimerCount()).toBe(timerCountAfterMount - 1);
+  });
+});

--- a/src/components/Panels/PropertiesPanel/PropertiesPanel.vue
+++ b/src/components/Panels/PropertiesPanel/PropertiesPanel.vue
@@ -11,16 +11,25 @@
 <script lang="ts" setup>
 import ModuleProperty from '#/components/Panels/PropertiesPanel/ModuleProperty/ModuleProperty.vue'
 import LayoutProperty from '#/components/Panels/PropertiesPanel/LayoutProperty/LayoutProperty.vue'
-import { toRaw, onMounted } from 'vue'
+import { toRaw, onMounted, onUnmounted } from 'vue'
 import { showPropertiesPanel } from './PropertiesPanel';
 import { usePropertiesPanelStore } from '#/store/propertiesPanelStore';
 import { setupPanelListeners } from '#/simulator/src/ux';
 
 const propertiesPanelStore = usePropertiesPanelStore();
 
+let propertiesPanelInterval: ReturnType<typeof setInterval> | null = null
+
 onMounted(() => {
     // checks for which type of properties panel to show
-    setInterval(showPropertiesPanel, 100)
+    propertiesPanelInterval = setInterval(showPropertiesPanel, 100)
     setupPanelListeners('#moduleProperty')
+})
+
+onUnmounted(() => {
+    if (propertiesPanelInterval) {
+        clearInterval(propertiesPanelInterval)
+        propertiesPanelInterval = null
+    }
 })
 </script>


### PR DESCRIPTION
## Summary
`PropertiesPanel.vue`'s `onMounted` hook started a `setInterval(showPropertiesPanel, 100)`
polling loop but never stored or cleared it, leaking an interval every time the
component mounted. Added `onUnmounted` to clear it, mirroring the already-correct
pattern in `PropertiesPanelMobile.vue`.

Related to #469 — this addresses the `PropertiesPanel.vue` file specifically;
other files listed in that issue are being claimed/handled separately.

## Test plan
- Added `PropertiesPanel.spec.ts`: mounts the component, confirms a timer is
  running, unmounts, and asserts the timer count drops by one (no leak).
- Full test suite passes (68/68 tests, 11 files).
- `yarn lint` — 0 errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented background polling from continuing after the Properties panel is closed or removed, improving resource usage and stability.

* **Tests**
  * Added automated coverage to verify that polling timers are properly cleared when the Properties panel is unmounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->