### PR TITLE
feat: add auto-focus functionality to MessageBox component in V1

### DIFF
--- a/v1/src/components/MessageBox/messageBox.vue
+++ b/v1/src/components/MessageBox/messageBox.vue
@@ -1,58 +1,63 @@
 <template>
-    <v-dialog :persistent="isPersistent">
-        <v-card class="messageBoxContent">
-            <v-card-text>
-                <!-- NOTE: Add v-ifs -->
-                <p v-if="messageText" style="font-weight: bold">
-                    {{ messageText }}
-                </p>
-                <template v-if="tableHeader.length == 0">
-                    <div
-                        v-for="inputItem in inputList"
-                        :id="inputItem.id"
-                        :key="inputItem.id"
-                        :style="inputItem.style"
-                        :class="inputClass"
+    <v-dialog :persistent="isPersistent" @after-enter="focusFirstInput">
+        <v-card ref="messageBoxCard" class="messageBoxContent">
+            <form @submit.prevent="handlePrimaryAction">
+                <v-card-text>
+                    <p v-if="messageText" style="font-weight: bold">
+                        {{ messageText }}
+                    </p>
+                    <template v-if="tableHeader.length == 0">
+                        <div
+                            v-for="inputItem in inputList"
+                            :id="inputItem.id"
+                            :key="inputItem.id"
+                            :style="inputItem.style"
+                            :class="inputClass"
+                        >
+                            <p>{{ inputItem.text }}</p>
+                            <input
+                                v-if="inputItem.type != 'nil'"
+                                v-model="inputItem.val"
+                                :class="inputItem.class"
+                                :placeholder="inputItem.placeholder"
+                                :type="inputItem.type"
+                            />
+                        </div>
+                    </template>
+                    <BooleanTable
+                        v-if="tableHeader.length > 0"
+                        :table-header="tableHeader"
+                        :table-body="tableBody"
+                    />
+                </v-card-text>
+                <v-card-actions>
+                    <v-btn
+                        v-for="buttonItem in buttonList"
+                        :key="buttonItem.text"
+                        class="messageBtn"
+                        block
+                        :type="
+                            buttonItem.emitOption === props.buttonList[0]?.emitOption
+                                ? 'submit'
+                                : 'button'
+                        "
+                        @click="handleButtonClick(buttonItem)"
                     >
-                        <p>{{ inputItem.text }}</p>
-                        <input
-                            v-if="inputItem.type != 'nil'"
-                            v-model="inputItem.val"
-                            :class="inputItem.class"
-                            :placeholder="inputItem.placeholder"
-                            :type="inputItem.type"
-                        />
-                    </div>
-                </template>
-                <BooleanTable
-                    v-if="tableHeader.length > 0"
-                    :table-header="tableHeader"
-                    :table-body="tableBody"
-                />
-            </v-card-text>
-            <v-card-actions>
-                <v-btn
-                    v-for="buttonItem in buttonList"
-                    :key="buttonItem.text"
-                    class="messageBtn"
-                    block
-                    @click="
-                        $emit('buttonClick', buttonItem.emitOption, circuitItem)
-                    "
-                >
-                    {{ buttonItem.text }}
-                </v-btn>
-            </v-card-actions>
+                        {{ buttonItem.text }}
+                    </v-btn>
+                </v-card-actions>
+            </form>
         </v-card>
     </v-dialog>
 </template>
 
 <script lang="ts" setup>
 import BooleanTable from '@/DialogBox/BooleanTable.vue'
+import { ref } from 'vue'
 
-defineEmits(['buttonClick'])
+const emit = defineEmits(['buttonClick'])
 
-defineProps({
+const props = defineProps({
     messageText: { type: String, default: '' },
     isPersistent: { type: Boolean, default: false },
     buttonList: {
@@ -77,6 +82,31 @@ defineProps({
     tableHeader: { type: Array, default: () => [] },
     tableBody: { type: Array, default: () => [] },
 })
+
+const messageBoxCard = ref(null)
+
+function focusFirstInput(): void {
+    const firstField = (messageBoxCard.value as any)?.$el?.querySelector('input')
+    firstField?.focus()
+}
+
+function handlePrimaryAction(): void {
+    const primaryButton = props.buttonList[0]
+
+    if (!primaryButton) {
+        return
+    }
+
+    emit('buttonClick', primaryButton.emitOption, props.circuitItem)
+}
+
+function handleButtonClick(buttonItem: { emitOption: string | boolean }): void {
+    if (buttonItem.emitOption === props.buttonList[0]?.emitOption) {
+        return
+    }
+
+    emit('buttonClick', buttonItem.emitOption, props.circuitItem)
+}
 </script>
 
 <style scoped></style>


### PR DESCRIPTION
Fixes #1152 

#### Describe the changes you have made in this PR -
- Added automatic text field focusing in the `messageBox.vue` component of `v1` by using the `@after-enter` event on `<v-dialog>`.
- Wrapped the dialog contents in a `<form @submit.prevent>` element to enable native Enter-key submission for inputs.
- Structured action buttons so that the primary option acts as the form's submit trigger (`type="submit"`), while other buttons act as standard buttons to prevent double-submission issues.

Screen Recording
Before-
[Screencast From 2026-09-09 23-10-56.webm](https://github.com/user-attachments/assets/b5e9eeeb-b1b5-4ca3-9593-e3f9d2d032f0)

After-
[Screencast From 2026-09-09 23-17-23.webm](https://github.com/user-attachments/assets/ad481761-6b54-40e6-9196-66219217d479)


## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
- **What problem does your code solve?**
  It fixes the issue where prompt dialog inputs (such as saving projects or creating new circuits) are not focused upon opening, requiring manual clicks to start typing, and where pressing Enter doesn't trigger the submit button.
- **What alternative approaches did you consider?**
  I considered setting custom `autofocus` attributes on the input fields or watching `v-model` changes to focus via a Vue ref. However, modal animations can cause standard autofocus to fail or fire before the element is active in the viewport. 
- **Why did you choose this specific implementation?**
  Re-implementing the V0 approach (using Vuetify's `@after-enter` transition event and native HTML `<form>` submission) is cleaner, more robust across browsers, and fixes the issue globally for all dialogs using `messageBox.vue` without modifying the calling components.
- **What are the key functions/components and what do they do?**
  - `focusFirstInput()`: Triggered once the dialog opens completely; finds the first input inside the dialog's DOM and calls `.focus()`.
  - `handlePrimaryAction()`: Automatically submits the form's primary action (the first option in `buttonList` like 'Save' or 'Create').
  - `handleButtonClick()`: Ensures secondary action buttons trigger their events, while ignoring the primary button's click since it's already handled natively by the form's submit event.


## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Dialogs now automatically focus the first available input when opened.
- Primary actions now submit consistently through the dialog form.
- Secondary buttons trigger their intended actions without causing duplicate primary-action events.
- Dialog table controls now respect their configured editability and starting-column settings.
- Input fields, tables, and action buttons remain correctly organized within the dialog form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

