### PR TITLE
docs: fix comment typo in simulator node helper

### DIFF
--- a/src/simulator/src/node.js
+++ b/src/simulator/src/node.js
@@ -353,7 +353,7 @@ export default class Node {
     }
 
     /**
-     * connects but doesnt draw the wire between nodes
+     * connects but doesn't draw the wire between nodes
      */
     connectWireLess(n) {
         if (n == this) return


### PR DESCRIPTION
## Summary

Fixes a small typo in a source comment.

## Why

Keeps comments clear and polished for contributors.
