### PR TITLE
docs: fix comment typo in v1 subcircuit prompt note

### DIFF
--- a/v1/src/simulator/src/subcircuit.ts
+++ b/v1/src/simulator/src/subcircuit.ts
@@ -33,7 +33,7 @@ export function loadSubCircuit(savedData: any, scope: any): void {
 }
 
 /**
- * Prompt to create subcircuit, shows list of circuits which dont depend on the current circuit
+ * Prompt to create subcircuit, shows list of circuits which don't depend on the current circuit
  * @param scope - The current scope
  * @category subcircuit
  */


### PR DESCRIPTION
## Summary

Fixes a small typo in a source comment.

## Why

Keeps comments clear and polished for contributors.
