### PR TITLE
feat(v1): add ELK auto-layout for canonical imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "codemirror-editor-vue3": "^2.1.7",
         "dom-to-image": "^2.6.0",
         "driver.js": "^0.9.8",
+        "elkjs": "^0.12.0",
         "interactjs": "^1.10.17",
         "jquery": "^3.6.0",
         "pinia": "^3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4718,6 +4718,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/elkjs": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.12.0.tgz",
+      "integrity": "sha512-YZcKynxVxYoKIOEpywEPwCFdg+BTbxQRNf3pbwdDCvc8O3kQD8bmIwSxKU1eOTVc4Xo+VG9Te+575mlfvOrhEQ==",
+      "license": "EPL-2.0 OR GPL-3.0-or-later"
+    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "codemirror-editor-vue3": "^2.1.7",
     "dom-to-image": "^2.6.0",
     "driver.js": "^0.9.8",
+    "elkjs": "^0.12.0",
     "interactjs": "^1.10.17",
     "jquery": "^3.6.0",
     "pinia": "^3.0.4",

--- a/v1/src/simulator/src/data/autoLayout.ts
+++ b/v1/src/simulator/src/data/autoLayout.ts
@@ -69,6 +69,7 @@ function addEdge(
   edgeInfo.set(id, info);
 }
 
+/** Returns component bounds after accounting for its rotation. */
 function getBounds(instance: LayoutInstance): Bounds {
   let left = instance.leftDimensionX;
   let right = instance.rightDimensionX;
@@ -88,6 +89,7 @@ function getBounds(instance: LayoutInstance): Bounds {
   return { left, right, up, down };
 }
 
+/** Chooses the ELK side nearest to a component-relative port. */
 function getPortDir(node: Node, bounds: Bounds): PortSide {
   if (node.x < -bounds.left) return "WEST";
   if (node.x > bounds.right) return "EAST";
@@ -183,6 +185,7 @@ function getElk(): ELK {
   return elk;
 }
 
+/** Converts canonical nets into direct ELK edges or synthetic fan-out junctions. */
 function buildElkEdges(
   nets: CanonicalNet[],
   instanceMap: Map<string, ComponentInstance>,
@@ -258,14 +261,7 @@ function buildElkEdges(
   return { edges, edgeInfo, junctions };
 }
 
-/** Groups each port reference by its component so node creation can look it up directly.
-* Eg:
-* CanoicalNet[]: ["and1.inputA", "and1.inputB", "led1.input"]
-* to:
-  {
-    and1: ["and1.inputA", "and1.inputB"];
-  }
-*/
+/** Groups each canonical port reference by its component ID. */
 function groupPortRefsByComponent(nets: CanonicalNet[]): Map<string, Set<string>> {
   const portRefsByComponent = new Map<string, Set<string>>();
 
@@ -325,13 +321,13 @@ function buildElkGraph(
   return { graph, edgeInfo, junctions };
 }
 
+/** Reuses or creates a canonical routing point without snapping it again. */
 function getOrAddNode(
   routing: IntermediateNet,
   nodeMap: Map<string, number>,
   point: ElkPoint,
 ): number {
-  const x = snap(point.x);
-  const y = snap(point.y);
+  const { x, y } = point;
   const key = `${x},${y}`;
 
   const existing = nodeMap.get(key);
@@ -357,7 +353,30 @@ function resolveEndpoint(
     throw new Error(`ELK did not position junction "${endpoint.id}"`);
   }
 
-  return getOrAddNode(routing, nodeMap, junctionPoint);
+  return getOrAddNode(routing, nodeMap, {
+    x: snap(junctionPoint.x),
+    y: snap(junctionPoint.y),
+  });
+}
+
+/** Returns how far an endpoint moves when its owner is snapped to the grid. */
+function getEndpointSnapDelta(
+  endpoint: EdgeEndpoint,
+  componentSnapDeltas: Map<string, ElkPoint>,
+  junctionPoints: Map<string, ElkPoint>,
+): ElkPoint {
+  if (endpoint.kind === "port") {
+    const componentId = endpoint.id.slice(0, endpoint.id.indexOf("."));
+    return componentSnapDeltas.get(componentId) ?? { x: 0, y: 0 };
+  }
+
+  const point = junctionPoints.get(endpoint.id);
+  if (!point) return { x: 0, y: 0 };
+
+  return {
+    x: snap(point.x) - point.x,
+    y: snap(point.y) - point.y,
+  };
 }
 
 function addConnection(
@@ -378,10 +397,17 @@ function addConnection(
   routing.connections.push([first, second]);
 }
 
+/** Treats nearly equal ELK coordinates as aligned. */
+function sameCoordinate(first: number, second: number): boolean {
+  return Math.abs(first - second) < 0.001;
+}
+
+/** Converts ELK routes into canonical orthogonal routing. */
 export function buildIntermediateNodes(
   edges: ElkExtendedEdge[],
   edgeInfo: Map<string, EdgeInfo>,
   junctionPoints: Map<string, ElkPoint>,
+  componentSnapDeltas: Map<string, ElkPoint> = new Map(),
 ): Record<string, IntermediateNet> {
   const result: Record<string, IntermediateNet> = {};
 
@@ -394,9 +420,65 @@ export function buildIntermediateNodes(
 
     const hasJunction = info.source.kind === "junction" || info.target.kind === "junction";
     const section = edge.sections?.[0];
-    const hasBends = (section?.bendPoints?.length ?? 0) > 0;
+    const sourceDelta = getEndpointSnapDelta(info.source, componentSnapDeltas, junctionPoints);
+    const targetDelta = getEndpointSnapDelta(info.target, componentSnapDeltas, junctionPoints);
+    const rawBendPoints = section?.bendPoints ?? [];
+    let bendPoints = rawBendPoints.map((point) => ({
+      x: snap(point.x),
+      y: snap(point.y),
+    }));
 
-    if (!hasJunction && !hasBends) continue;
+    // ELK may omit route data, so only adjust edges with a section.
+    if (section) {
+      if (bendPoints.length > 0) {
+        const first = rawBendPoints[0];
+        const last = rawBendPoints[rawBendPoints.length - 1];
+
+        if (sameCoordinate(section.startPoint.x, first.x)) {
+          bendPoints[0].x = section.startPoint.x + sourceDelta.x;
+        } else if (sameCoordinate(section.startPoint.y, first.y)) {
+          bendPoints[0].y = section.startPoint.y + sourceDelta.y;
+        }
+
+        if (sameCoordinate(section.endPoint.x, last.x)) {
+          bendPoints[bendPoints.length - 1].x = section.endPoint.x + targetDelta.x;
+        } else if (sameCoordinate(section.endPoint.y, last.y)) {
+          bendPoints[bendPoints.length - 1].y = section.endPoint.y + targetDelta.y;
+        }
+      } else {
+        // A straight ELK edge can become diagonal when its endpoints snap differently.
+        const sourcePoint = {
+          x: section.startPoint.x + sourceDelta.x,
+          y: section.startPoint.y + sourceDelta.y,
+        };
+        const targetPoint = {
+          x: section.endPoint.x + targetDelta.x,
+          y: section.endPoint.y + targetDelta.y,
+        };
+
+        // Add bends only when the snapped endpoints no longer share an axis.
+        if (
+          !sameCoordinate(sourcePoint.x, targetPoint.x) &&
+          !sameCoordinate(sourcePoint.y, targetPoint.y)
+        ) {
+          if (sameCoordinate(section.startPoint.y, section.endPoint.y)) {
+            const x = snap((sourcePoint.x + targetPoint.x) / 2);
+            bendPoints = [
+              { x, y: sourcePoint.y },
+              { x, y: targetPoint.y },
+            ];
+          } else if (sameCoordinate(section.startPoint.x, section.endPoint.x)) {
+            const y = snap((sourcePoint.y + targetPoint.y) / 2);
+            bendPoints = [
+              { x: sourcePoint.x, y },
+              { x: targetPoint.x, y },
+            ];
+          }
+        }
+      }
+    }
+
+    if (!hasJunction && bendPoints.length === 0) continue;
 
     let state = routingStateByNet.get(info.netId);
     if (!state) {
@@ -431,7 +513,7 @@ export function buildIntermediateNodes(
 
     const path: (string | number)[] = [
       source,
-      ...(section.bendPoints ?? []).map((point) => getOrAddNode(routing, nodeMap, point)),
+      ...bendPoints.map((point) => getOrAddNode(routing, nodeMap, point)),
       target,
     ];
 
@@ -478,6 +560,7 @@ function defaultSubcircuitSymbol(instanceMap: Map<string, ComponentInstance>): S
   };
 }
 
+/** Generates component positions and canonical routing for a layoutless scope. */
 export async function generateElkLayout(
   components: CanonicalComponent[],
   nets: CanonicalNet[],
@@ -492,6 +575,7 @@ export async function generateElkLayout(
 
   const junctionIds = new Set(junctions.map((junction) => junction.id));
   const junctionPoints = new Map<string, ElkPoint>();
+  const componentSnapDeltas = new Map<string, ElkPoint>();
 
   for (const child of laidOut.children ?? []) {
     if (junctionIds.has(child.id)) {
@@ -525,15 +609,28 @@ export async function generateElkLayout(
     }
 
     const bounds = getBounds(instance);
+    const x = child.x + bounds.left;
+    const y = child.y + bounds.up;
+    const X = snap(x);
+    const Y = snap(y);
 
     layout[child.id] = {
-      x: snap(child.x + bounds.left),
-      y: snap(child.y + bounds.up),
+      x: X,
+      y: Y,
       labelDirection: instance.labelDirection,
     };
+    componentSnapDeltas.set(child.id, {
+      x: X - x,
+      y: Y - y,
+    });
   }
 
-  const intermediateNodes = buildIntermediateNodes(laidOut.edges ?? [], edgeInfo, junctionPoints);
+  const intermediateNodes = buildIntermediateNodes(
+    laidOut.edges ?? [],
+    edgeInfo,
+    junctionPoints,
+    componentSnapDeltas,
+  );
   if (Object.keys(intermediateNodes).length > 0) {
     layout.intermediateNodes = intermediateNodes;
   }

--- a/v1/src/simulator/src/data/autoLayout.ts
+++ b/v1/src/simulator/src/data/autoLayout.ts
@@ -24,6 +24,7 @@ type LayoutInstance = ComponentInstance & {
   rightDimensionX: number;
   upDimensionY: number;
   downDimensionY: number;
+  nodeList: Node[];
 };
 
 type Bounds = {
@@ -84,6 +85,14 @@ function getBounds(instance: LayoutInstance): Bounds {
     } else if (instance.direction === "UP") {
       [left, right, up, down] = [down, up, right, left];
     }
+  }
+
+  // Include ports that extend beyond the component body.
+  for (const node of instance.nodeList) {
+    left = Math.max(left, -node.x);
+    right = Math.max(right, node.x);
+    up = Math.max(up, -node.y);
+    down = Math.max(down, node.y);
   }
 
   return { left, right, up, down };

--- a/v1/src/simulator/src/data/autoLayout.ts
+++ b/v1/src/simulator/src/data/autoLayout.ts
@@ -1,0 +1,542 @@
+import ELKConstructor from "elkjs/lib/elk-api.js";
+import type { ELK, ElkExtendedEdge, ElkNode, ElkPoint, ElkPort } from "elkjs/lib/elk-api.js";
+import ELKWorker from "elkjs/lib/elk-worker.min.js?worker";
+import type Node from "../node";
+import type {
+  CanonicalComponent,
+  CanonicalLayout,
+  CanonicalNet,
+  ComponentInstance,
+  Direction,
+  IntermediateNet,
+  RoutingEndpoint,
+  SubcircuitSymbol,
+} from "../types/canonical.types";
+import { resolvePortNode } from "./importCanonical";
+
+type LayoutInstance = ComponentInstance & {
+  objectType: string;
+  layoutProperties?: { x?: number; y?: number };
+  direction: Direction;
+  directionFixed?: boolean;
+  overrideDirectionRotation?: boolean;
+  leftDimensionX: number;
+  rightDimensionX: number;
+  upDimensionY: number;
+  downDimensionY: number;
+};
+
+type Bounds = {
+  left: number;
+  right: number;
+  up: number;
+  down: number;
+};
+
+type EdgeEndpoint = { kind: "port"; id: string } | { kind: "junction"; id: string };
+
+type EdgeInfo = {
+  netId: string;
+  source: EdgeEndpoint;
+  target: EdgeEndpoint;
+};
+
+type ElkEdgeData = {
+  edges: ElkExtendedEdge[];
+  edgeInfo: Map<string, EdgeInfo>;
+  junctions: ElkNode[];
+};
+
+type RoutingState = {
+  routing: IntermediateNet;
+  nodeMap: Map<string, number>;
+  connectionKeys: Set<string>;
+};
+
+type PortSide = "NORTH" | "EAST" | "WEST" | "SOUTH";
+
+function addEdge(
+  edges: ElkExtendedEdge[],
+  edgeInfo: Map<string, EdgeInfo>,
+  id: string,
+  info: EdgeInfo,
+): void {
+  edges.push({
+    id,
+    sources: [info.source.id],
+    targets: [info.target.id],
+  });
+  edgeInfo.set(id, info);
+}
+
+function getBounds(instance: LayoutInstance): Bounds {
+  let left = instance.leftDimensionX;
+  let right = instance.rightDimensionX;
+  let up = instance.upDimensionY;
+  let down = instance.downDimensionY;
+
+  if (!instance.directionFixed && !instance.overrideDirectionRotation) {
+    if (instance.direction === "LEFT") {
+      [left, right] = [right, left];
+    } else if (instance.direction === "DOWN") {
+      [left, right, up, down] = [down, up, left, right];
+    } else if (instance.direction === "UP") {
+      [left, right, up, down] = [down, up, right, left];
+    }
+  }
+
+  return { left, right, up, down };
+}
+
+function getPortDir(node: Node, bounds: Bounds): PortSide {
+  if (node.x < -bounds.left) return "WEST";
+  if (node.x > bounds.right) return "EAST";
+  if (node.y < -bounds.up) return "NORTH";
+  if (node.y > bounds.down) return "SOUTH";
+
+  const distances = [
+    {
+      side: "WEST" as const,
+      distance: Math.abs(node.x + bounds.left),
+    },
+    {
+      side: "EAST" as const,
+      distance: Math.abs(bounds.right - node.x),
+    },
+    {
+      side: "NORTH" as const,
+      distance: Math.abs(node.y + bounds.up),
+    },
+    {
+      side: "SOUTH" as const,
+      distance: Math.abs(bounds.down - node.y),
+    },
+  ];
+
+  distances.sort((a, b) => a.distance - b.distance);
+  return distances[0].side;
+}
+
+function buildElkNodes(
+  components: CanonicalComponent[],
+  instanceMap: Map<string, ComponentInstance>,
+  portRefsByComponent: Map<string, Set<string>>,
+): ElkNode[] {
+  return components.map((component) => {
+    const instance = instanceMap.get(component.id) as LayoutInstance | undefined;
+
+    if (!instance) {
+      throw new Error(`Cannot build ELK node for component "${component.id}"`);
+    }
+
+    const bounds = getBounds(instance);
+
+    const ports: ElkPort[] = [];
+
+    for (const portRef of portRefsByComponent.get(component.id) ?? []) {
+      const node = resolvePortNode(portRef, instanceMap);
+
+      if (!node) {
+        throw new Error(`Cannot resolve ELK port "${portRef}"`);
+      }
+
+      ports.push({
+        id: portRef,
+        x: node.x + bounds.left,
+        y: node.y + bounds.up,
+        layoutOptions: {
+          "elk.port.side": getPortDir(node, bounds),
+        },
+      });
+    }
+
+    const compLayoutOptions: Record<string, string> = {
+      "elk.portConstraints": "FIXED_POS",
+    };
+
+    if (component.type === "Input") {
+      compLayoutOptions["elk.layered.layering.layerConstraint"] = "FIRST";
+    }
+
+    if (component.type === "Output") {
+      compLayoutOptions["elk.layered.layering.layerConstraint"] = "LAST";
+    }
+
+    return {
+      id: component.id,
+      width: bounds.left + bounds.right,
+      height: bounds.up + bounds.down,
+      ports,
+      layoutOptions: compLayoutOptions,
+    };
+  });
+}
+
+let elk: ELK | undefined;
+
+function getElk(): ELK {
+  elk ??= new ELKConstructor({
+    algorithms: ["layered"],
+    workerFactory: () => new ELKWorker(),
+  });
+
+  return elk;
+}
+
+function buildElkEdges(
+  nets: CanonicalNet[],
+  instanceMap: Map<string, ComponentInstance>,
+): ElkEdgeData {
+  const edges: ElkExtendedEdge[] = [];
+  const edgeInfo = new Map<string, EdgeInfo>();
+  const junctions: ElkNode[] = [];
+
+  for (const net of nets) {
+    if (net.connections.length < 2) continue;
+
+    const sourceId =
+      net.connections.find((portRef) => resolvePortNode(portRef, instanceMap)?.type === 1) ??
+      net.connections[0];
+
+    const source: EdgeEndpoint = {
+      kind: "port",
+      id: sourceId,
+    };
+
+    const targets = net.connections.filter((portRef) => portRef !== sourceId);
+    const firstEdgeId = `${net.id}_0`;
+
+    if (targets.length === 1) {
+      const target: EdgeEndpoint = {
+        kind: "port",
+        id: targets[0],
+      };
+
+      addEdge(edges, edgeInfo, firstEdgeId, {
+        netId: net.id,
+        source,
+        target,
+      });
+
+      continue;
+    }
+
+    const junctionId = `junction_${net.id}`;
+    const junction: EdgeEndpoint = {
+      kind: "junction",
+      id: junctionId,
+    };
+
+    junctions.push({
+      id: junctionId,
+      width: 0,
+      height: 0,
+      layoutOptions: {
+        "elk.hypernode": "true",
+      },
+    });
+
+    addEdge(edges, edgeInfo, firstEdgeId, {
+      netId: net.id,
+      source,
+      target: junction,
+    });
+
+    for (let i = 0; i < targets.length; i++) {
+      const id = `${net.id}_${i + 1}`;
+      addEdge(edges, edgeInfo, id, {
+        netId: net.id,
+        source: junction,
+        target: {
+          kind: "port",
+          id: targets[i],
+        },
+      });
+    }
+  }
+
+  return { edges, edgeInfo, junctions };
+}
+
+/** Groups each port reference by its component so node creation can look it up directly.
+* Eg:
+* CanoicalNet[]: ["and1.inputA", "and1.inputB", "led1.input"]
+* to:
+  {
+    and1: ["and1.inputA", "and1.inputB"];
+  }
+*/
+function groupPortRefsByComponent(nets: CanonicalNet[]): Map<string, Set<string>> {
+  const portRefsByComponent = new Map<string, Set<string>>();
+
+  for (const net of nets) {
+    for (const portRef of net.connections) {
+      const separator = portRef.indexOf(".");
+      if (separator < 1) continue;
+
+      const componentId = portRef.slice(0, separator);
+      let portRefs = portRefsByComponent.get(componentId);
+      if (!portRefs) {
+        portRefs = new Set();
+        portRefsByComponent.set(componentId, portRefs);
+      }
+      portRefs.add(portRef);
+    }
+  }
+
+  return portRefsByComponent;
+}
+
+function buildElkGraph(
+  components: CanonicalComponent[],
+  nets: CanonicalNet[],
+  instanceMap: Map<string, ComponentInstance>,
+) {
+  const portRefsByComponent = groupPortRefsByComponent(nets);
+  const children = buildElkNodes(components, instanceMap, portRefsByComponent);
+  const { edges, edgeInfo, junctions } = buildElkEdges(nets, instanceMap);
+
+  const graph: ElkNode = {
+    id: "root",
+    children: [...children, ...junctions],
+    edges,
+    layoutOptions: {
+      "elk.algorithm": "layered",
+      "elk.direction": "RIGHT",
+      "elk.edgeRouting": "ORTHOGONAL",
+      "elk.padding": "[top=40,left=40,bottom=40,right=40]",
+
+      // More room between components in the same layer.
+      "elk.spacing.nodeNode": "40",
+
+      // More horizontal separation between successive logic layers.
+      "elk.layered.spacing.nodeNodeBetweenLayers": "60",
+
+      // Keep wires from running too close to components.
+      "elk.spacing.edgeNode": "20",
+      "elk.layered.spacing.edgeNodeBetweenLayers": "20",
+
+      // Separate parallel wires a little more.
+      "elk.spacing.edgeEdge": "15",
+      "elk.layered.spacing.edgeEdgeBetweenLayers": "15",
+    },
+  };
+
+  return { graph, edgeInfo, junctions };
+}
+
+function getOrAddNode(
+  routing: IntermediateNet,
+  nodeMap: Map<string, number>,
+  point: ElkPoint,
+): number {
+  const x = snap(point.x);
+  const y = snap(point.y);
+  const key = `${x},${y}`;
+
+  const existing = nodeMap.get(key);
+  if (existing !== undefined) return existing;
+
+  const index = routing.nodes.length;
+
+  routing.nodes.push({ x, y });
+  nodeMap.set(key, index);
+
+  return index;
+}
+
+function resolveEndpoint(
+  endpoint: EdgeEndpoint,
+  junctionPoint: ElkPoint | undefined,
+  routing: IntermediateNet,
+  nodeMap: Map<string, number>,
+): RoutingEndpoint {
+  if (endpoint.kind === "port") return endpoint.id;
+
+  if (!junctionPoint) {
+    throw new Error(`ELK did not position junction "${endpoint.id}"`);
+  }
+
+  return getOrAddNode(routing, nodeMap, junctionPoint);
+}
+
+function addConnection(
+  routing: IntermediateNet,
+  connectionKeys: Set<string>,
+  first: RoutingEndpoint,
+  second: RoutingEndpoint,
+): void {
+  if (first === second) return;
+
+  const firstKey = typeof first === "number" ? `node:${first}` : `port:${first}`;
+  const secondKey = typeof second === "number" ? `node:${second}` : `port:${second}`;
+  const key = firstKey < secondKey ? `${firstKey}|${secondKey}` : `${secondKey}|${firstKey}`;
+
+  if (connectionKeys.has(key)) return;
+
+  connectionKeys.add(key);
+  routing.connections.push([first, second]);
+}
+
+export function buildIntermediateNodes(
+  edges: ElkExtendedEdge[],
+  edgeInfo: Map<string, EdgeInfo>,
+  junctionPoints: Map<string, ElkPoint>,
+): Record<string, IntermediateNet> {
+  const result: Record<string, IntermediateNet> = {};
+
+  const routingStateByNet = new Map<string, RoutingState>();
+
+  // Build the actual canonical routing for each ELK edge.
+  for (const edge of edges) {
+    const info = edgeInfo.get(edge.id);
+    if (!info) continue;
+
+    const hasJunction = info.source.kind === "junction" || info.target.kind === "junction";
+    const section = edge.sections?.[0];
+    const hasBends = (section?.bendPoints?.length ?? 0) > 0;
+
+    if (!hasJunction && !hasBends) continue;
+
+    let state = routingStateByNet.get(info.netId);
+    if (!state) {
+      state = {
+        routing: { nodes: [], connections: [] },
+        nodeMap: new Map(),
+        connectionKeys: new Set(),
+      };
+      routingStateByNet.set(info.netId, state);
+      result[info.netId] = state.routing;
+    }
+
+    const { routing, nodeMap, connectionKeys } = state;
+    const source = resolveEndpoint(
+      info.source,
+      junctionPoints.get(info.source.id),
+      routing,
+      nodeMap,
+    );
+    const target = resolveEndpoint(
+      info.target,
+      junctionPoints.get(info.target.id),
+      routing,
+      nodeMap,
+    );
+
+    // If ELK returned no section, connect the two known endpoints directly.
+    if (!section) {
+      addConnection(routing, connectionKeys, source, target);
+      continue;
+    }
+
+    const path: (string | number)[] = [
+      source,
+      ...(section.bendPoints ?? []).map((point) => getOrAddNode(routing, nodeMap, point)),
+      target,
+    ];
+
+    for (let i = 1; i < path.length; i++) {
+      addConnection(routing, connectionKeys, path[i - 1], path[i]);
+    }
+  }
+
+  return result;
+}
+
+const GRID_SIZE = 10;
+
+function snap(value: number): number {
+  return Math.round(value / GRID_SIZE) * GRID_SIZE;
+}
+
+function defaultSubcircuitSymbol(instanceMap: Map<string, ComponentInstance>): SubcircuitSymbol {
+  let width = 100;
+  let height = 40;
+
+  for (const value of instanceMap.values()) {
+    const instance = value as LayoutInstance;
+    if (instance.objectType !== "Input" && instance.objectType !== "Output") continue;
+
+    const x = instance.layoutProperties?.x;
+    const y = instance.layoutProperties?.y;
+
+    if (typeof x === "number" && Number.isFinite(x)) width = Math.max(width, x);
+    if (typeof y === "number" && Number.isFinite(y)) {
+      height = Math.max(height, y + GRID_SIZE * 2);
+    }
+  }
+
+  width = snap(width);
+  height = snap(height);
+
+  return {
+    width,
+    height,
+    titleX: width / 2,
+    titleY: 13,
+    titleEnabled: true,
+  };
+}
+
+export async function generateElkLayout(
+  components: CanonicalComponent[],
+  nets: CanonicalNet[],
+  instanceMap: Map<string, ComponentInstance>,
+): Promise<CanonicalLayout> {
+  const { graph, edgeInfo, junctions } = buildElkGraph(components, nets, instanceMap);
+
+  const laidOut = await getElk().layout(graph);
+  const layout: CanonicalLayout = {
+    subcircuitSymbol: defaultSubcircuitSymbol(instanceMap),
+  };
+
+  const junctionIds = new Set(junctions.map((junction) => junction.id));
+  const junctionPoints = new Map<string, ElkPoint>();
+
+  for (const child of laidOut.children ?? []) {
+    if (junctionIds.has(child.id)) {
+      if (
+        child.x === undefined ||
+        child.y === undefined ||
+        !Number.isFinite(child.x) ||
+        !Number.isFinite(child.y)
+      ) {
+        throw new Error(`ELK did not position junction "${child.id}"`);
+      }
+
+      junctionPoints.set(child.id, {
+        x: child.x,
+        y: child.y,
+      });
+
+      continue;
+    }
+
+    const instance = instanceMap.get(child.id) as LayoutInstance | undefined;
+    if (!instance) continue;
+
+    if (
+      child.x === undefined ||
+      child.y === undefined ||
+      !Number.isFinite(child.x) ||
+      !Number.isFinite(child.y)
+    ) {
+      throw new Error(`ELK did not position component "${child.id}"`);
+    }
+
+    const bounds = getBounds(instance);
+
+    layout[child.id] = {
+      x: snap(child.x + bounds.left),
+      y: snap(child.y + bounds.up),
+      labelDirection: instance.labelDirection,
+    };
+  }
+
+  const intermediateNodes = buildIntermediateNodes(laidOut.edges ?? [], edgeInfo, junctionPoints);
+  if (Object.keys(intermediateNodes).length > 0) {
+    layout.intermediateNodes = intermediateNodes;
+  }
+
+  return layout;
+}

--- a/v1/src/simulator/src/data/importCanonical.ts
+++ b/v1/src/simulator/src/data/importCanonical.ts
@@ -438,19 +438,13 @@ async function importSingleScope(
     return buildErrors;
   }
 
-  // const FORCE_AUTO_LAYOUT = true;
-
-  // if (layout === undefined || FORCE_AUTO_LAYOUT) {
   if (layout === undefined) {
     try {
       const { generateElkLayout } = await import("./autoLayout");
       layout = await generateElkLayout(components, nets, instanceMap);
     } catch (err) {
-      buildErrors.push(`Auto Layout Failed. Error: ${err}`);
+      return [`Auto layout failed: ${errorMessage(err)}`];
     }
-  }
-  if (buildErrors.length > 0) {
-    return buildErrors;
   }
 
   const layoutErrors = applyComponentLayout(instanceMap, layout);

--- a/v1/src/simulator/src/data/importCanonical.ts
+++ b/v1/src/simulator/src/data/importCanonical.ts
@@ -64,7 +64,7 @@ function getConstructorParams(properties: CanonicalComponent["properties"]): Can
 function buildComponents(
   scope: Scope,
   components: CanonicalComponent[],
-  layout: CanonicalLayout,
+  layout: CanonicalLayout | undefined,
   scopeMap: Map<number, Scope>,
 ): { instanceMap: Map<string, ComponentInstance>; errors: string[] } {
   const instanceMap = new Map<string, ComponentInstance>();
@@ -74,7 +74,9 @@ function buildComponents(
 
   for (let i = 0; i < components.length; i++) {
     const { id, type, label, properties } = components[i];
-    const position = layout[id] as CanonicalComponentPosition;
+    const position = layout?.[id] as CanonicalComponentPosition | undefined;
+    const x = position?.x ?? 0;
+    const y = position?.y ?? 0;
 
     let instance: ComponentInstance;
 
@@ -86,12 +88,7 @@ function buildComponents(
       }
 
       try {
-        instance = new SubCircuit(
-          position.x,
-          position.y,
-          scope,
-          String(subcircuitId),
-        ) as ComponentInstance;
+        instance = new SubCircuit(x, y, scope, String(subcircuitId)) as ComponentInstance;
       } catch (err) {
         errors.push(`SubCircuit "${id}": ${errorMessage(err)}`);
         continue;
@@ -106,7 +103,7 @@ function buildComponents(
       const constructorArgs = getConstructorParams(properties);
 
       try {
-        instance = new Constructor(position.x, position.y, scope, ...constructorArgs);
+        instance = new Constructor(x, y, scope, ...constructorArgs);
       } catch (err) {
         errors.push(`"${id}" (${type}): ${errorMessage(err)}`);
         continue;
@@ -117,12 +114,12 @@ function buildComponents(
 
     instance.propagationDelay = properties.propagationDelay;
 
-    instance.labelDirection = position.labelDirection;
+    if (position) instance.labelDirection = position.labelDirection;
 
-    const metadata = position.subcircuitMetadata;
+    const metadata = position?.subcircuitMetadata;
     if (metadata) {
       Reflect.set(instance, "subcircuitMetadata", { ...metadata });
-    } else if (Reflect.get(instance, "canShowInSubcircuit")) {
+    } else if (Reflect.get(instance, "canShowInSubcircuit") && position) {
       Reflect.get(instance, "subcircuitMetadata").labelDirection = position.labelDirection;
     }
 
@@ -130,9 +127,10 @@ function buildComponents(
   }
 
   for (const comp of components) {
-    const positions = (layout[comp.id] as CanonicalComponentPosition).portPositions;
-    if (positions === undefined) continue;
-    for (const [portName, point] of Object.entries(positions)) {
+    const position = layout?.[comp.id] as CanonicalComponentPosition | undefined;
+    if (!position?.portPositions) continue;
+
+    for (const [portName, point] of Object.entries(position.portPositions)) {
       const node = resolvePortNode(`${comp.id}.${portName}`, instanceMap);
       if (!node) {
         errors.push(`"${comp.id}.${portName}": port not found`);
@@ -145,6 +143,23 @@ function buildComponents(
   }
 
   return { instanceMap, errors };
+}
+
+function applyComponentLayout(
+  instanceMap: Map<string, ComponentInstance>,
+  layout: CanonicalLayout,
+): string[] {
+  const errors: string[] = [];
+  for (const [id, instance] of instanceMap) {
+    const pos = layout[id] as CanonicalComponentPosition | undefined;
+    if (!pos || !Number.isFinite(pos.x) || !Number.isFinite(pos.y)) {
+      errors.push(`Layout is missing for component "${id}"`);
+      continue;
+    }
+    Reflect.set(instance, "x", pos.x);
+    Reflect.set(instance, "y", pos.y);
+  }
+  return errors;
 }
 
 function buildAnnotations(scope: Scope, annotations?: CanonicalAnnotation[]): string[] {
@@ -180,7 +195,7 @@ function buildAnnotations(scope: Scope, annotations?: CanonicalAnnotation[]): st
 }
 
 /** Resolves a "ComponentId.portName" reference string to a live Node on the constructed instance. */
-function resolvePortNode(
+export function resolvePortNode(
   portRef: string,
   instanceMap: Map<string, ComponentInstance>,
 ): Node | null {
@@ -354,7 +369,11 @@ function restoreIntermediateNodes(
 }
 
 /** Copies visual metadata from the canonical JSON back onto the scope object. */
-function restoreScopeMetadata(scope: Scope, circuitData: CanonicalScope): void {
+function restoreScopeMetadata(
+  scope: Scope,
+  circuitData: CanonicalScope,
+  layout: CanonicalLayout,
+): void {
   scope.name = circuitData.projectMetadata.name;
   scope.restrictedCircuitElementsUsed = [...circuitData.projectMetadata.restrictedElementsUsed];
 
@@ -368,7 +387,7 @@ function restoreScopeMetadata(scope: Scope, circuitData: CanonicalScope): void {
     scope.centerFocus(false);
   }
 
-  const sym = circuitData.layout.subcircuitSymbol;
+  const sym = layout.subcircuitSymbol;
   scope.layout = {
     width: sym.width,
     height: sym.height,
@@ -411,13 +430,31 @@ async function importSingleScope(
   originalChildHashes?: Map<number, string>,
 ): Promise<string[]> {
   const { components, nets } = circuitData.netlist;
-  const { layout } = circuitData;
+  let layout: CanonicalLayout | undefined = circuitData.layout;
 
   const { instanceMap, errors: buildErrors } = buildComponents(scope, components, layout, scopeMap);
 
   if (buildErrors.length > 0) {
     return buildErrors;
   }
+
+  // const FORCE_AUTO_LAYOUT = true;
+
+  // if (layout === undefined || FORCE_AUTO_LAYOUT) {
+  if (layout === undefined) {
+    try {
+      const { generateElkLayout } = await import("./autoLayout");
+      layout = await generateElkLayout(components, nets, instanceMap);
+    } catch (err) {
+      buildErrors.push(`Auto Layout Failed. Error: ${err}`);
+    }
+  }
+  if (buildErrors.length > 0) {
+    return buildErrors;
+  }
+
+  const layoutErrors = applyComponentLayout(instanceMap, layout);
+  if (layoutErrors.length > 0) return layoutErrors;
 
   const annotationErrors = buildAnnotations(scope, layout.annotations);
 
@@ -428,7 +465,7 @@ async function importSingleScope(
     ? restoreIntermediateNodes(scope, layout.intermediateNodes, instanceMap, nets)
     : [];
 
-  restoreScopeMetadata(scope, circuitData);
+  restoreScopeMetadata(scope, circuitData, layout);
 
   const allErrors = [...annotationErrors, ...wireErrors, ...stateErrors, ...routingErrors];
 


### PR DESCRIPTION
Fixes #1211

#### Describe the changes you have made in this PR -

- Added `elkjs` as a project dependency and dynamically load the auto-layout module only when layout generation is required.
- Added ELK.js-based automatic layout generation for canonical circuits that do not contain layout data.
- Added a worker-based ELK layered layout with left-to-right component placement and orthogonal wire routing.
- Preserved existing canonical layouts by only running auto-layout when the imported circuit has no layout.
- Used actual component dimensions, directions, and fixed port positions while constructing the ELK graph.
- Constrained `Input` components to the first layer and `Output` components to the last layer for a more natural circuit flow.
- Added synthetic zero-size junction nodes for fan-out nets while keeping every ELK edge as a one-source to one-target connection.
- Converted ELK bend points and junction positions back into canonical intermediate routing nodes and connections.
- Deduplicated generated routing nodes and connections and snapped generated coordinates to the simulator grid.

### Screenshots of the UI changes (If any) -

https://github.com/user-attachments/assets/6752888b-8bf0-472c-913a-b196927da0ae



---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance

**Explain your implementation approach:**

- When canonical layout data is missing, components are first constructed without depending on saved coordinates so their dimensions and ports are available for layout generation.
- I convert the circuit into an ELK graph using the actual component dimensions and port positions. ELK then uses its layered algorithm with orthogonal routing to calculate component positions and wire paths.
- For two-terminal nets, a normal source-to-target ELK edge is used. For fan-out nets, I use a temporary zero-size junction with a source-to-junction and junction-to-target branches so the shared net topology is represented explicitly during layout.
- After ELK finishes, the generated component positions, bend points, and junction positions are converted back into the canonical layout format.
- Generated coordinates are snapped to the simulator grid, while duplicate routing nodes and connections are avoided.
- The ELK-specific junction representation exists only inside the auto-layout adapter and is converted back into the existing canonical routing representation before the normal import flow continues.
- Circuits that already contain layout data continue using their saved layout and do not run ELK auto-layout.

---

## Checklist before requesting a review

- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic circuit layout generation when layout data is unavailable.
  * Improved routing for complex connections, including multi-target nets and intermediate junctions.
  * Added grid-aligned component and connection positioning.
  * Added orthogonal routing with automatic bends for cleaner circuit diagrams.
* **Bug Fixes**
  * Improved circuit loading when component layout information is missing by applying safe default positions.
  * Preserved component labels, metadata, port positions, and scope information during automatic layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->