### PR TITLE
fix(bit-converter): pass the decoded BCD value to setBaseValues

### DIFF
--- a/src/simulator/spec/bitConvertor.spec.js
+++ b/src/simulator/spec/bitConvertor.spec.js
@@ -80,6 +80,26 @@ describe('data dir working', () => {
         expect(() => setupBitConvertor()).not.toThrow();
     });
 
+    test('bcd input updates the other fields', () => {
+        setupBitConvertor();
+        // 0010 0101 is the BCD encoding of the decimal number 25.
+        $('#bcdInput').val('00100101');
+        $('#bcdInput').trigger('keyup');
+        expect($('#decimalInput').val()).toBe('25');
+        expect($('#hexInput').val()).toBe('0x19');
+        expect($('#binaryInput').val()).toBe('0b11001');
+        expect($('#octalInput').val()).toBe('031');
+    });
+
+    test('bcd input rejects a nibble that is not a decimal digit', () => {
+        setupBitConvertor();
+        setBaseValues(7);
+        // 1010 is 10, which is not a valid BCD digit, so nothing should update.
+        $('#bcdInput').val('1010');
+        $('#bcdInput').trigger('keyup');
+        expect($('#decimalInput').val()).toBe('7');
+    });
+
     test('function setBaseValues working', () => {
         const randomBaseValue = Math.floor(Math.random() * 100);
         console.log('Testing for Base Value --> ', randomBaseValue);

--- a/src/simulator/spec/bitConvertor.spec.js
+++ b/src/simulator/spec/bitConvertor.spec.js
@@ -89,6 +89,9 @@ describe('data dir working', () => {
         expect($('#hexInput').val()).toBe('0x19');
         expect($('#binaryInput').val()).toBe('0b11001');
         expect($('#octalInput').val()).toBe('031');
+        // setBaseValues writes the field back through dec2bcd, which drops the
+        // leading nibble's zeros, so the typed 00100101 comes back as 100101.
+        expect($('#bcdInput').val()).toBe('100101');
     });
 
     test('bcd input rejects a nibble that is not a decimal digit', () => {

--- a/src/simulator/src/utils.ts
+++ b/src/simulator/src/utils.ts
@@ -288,7 +288,7 @@ export function setupBitConvertor() {
         i++;
       }
     }
-    return setBaseValues(x);
+    return setBaseValues(num);
   });
 
   $("#hexInput").on("keyup", function () {

--- a/v1/src/simulator/spec/bitConvertor.spec.js
+++ b/v1/src/simulator/spec/bitConvertor.spec.js
@@ -80,6 +80,29 @@ describe('data dir working', () => {
         expect(() => setupBitConvertor()).not.toThrow();
     });
 
+    test('bcd input updates the other fields', () => {
+        setupBitConvertor();
+        // 0010 0101 is the BCD encoding of the decimal number 25.
+        $('#bcdInput').val('00100101');
+        $('#bcdInput').trigger('keyup');
+        expect($('#decimalInput').val()).toBe('25');
+        expect($('#hexInput').val()).toBe('0x19');
+        expect($('#binaryInput').val()).toBe('0b11001');
+        expect($('#octalInput').val()).toBe('031');
+        // setBaseValues writes the field back through dec2bcd, which drops the
+        // leading nibble's zeros, so the typed 00100101 comes back as 100101.
+        expect($('#bcdInput').val()).toBe('100101');
+    });
+
+    test('bcd input rejects a nibble that is not a decimal digit', () => {
+        setupBitConvertor();
+        setBaseValues(7);
+        // 1010 is 10, which is not a valid BCD digit, so nothing should update.
+        $('#bcdInput').val('1010');
+        $('#bcdInput').trigger('keyup');
+        expect($('#decimalInput').val()).toBe('7');
+    });
+
     test('function setBaseValues working', () => {
         const randomBaseValue = Math.floor(Math.random() * 100);
         console.log('Testing for Base Value --> ', randomBaseValue);

--- a/v1/src/simulator/src/utils.ts
+++ b/v1/src/simulator/src/utils.ts
@@ -288,7 +288,7 @@ export function setupBitConvertor() {
         i++;
       }
     }
-    return setBaseValues(x);
+    return setBaseValues(num);
   });
 
   $("#hexInput").on("keyup", function () {


### PR DESCRIPTION
Fixes #1228

#### Describe the changes you have made in this PR -

The BCD field in the Hex/Bin/Dec converter dialog did nothing. Typing into it threw `ReferenceError: x is not defined`, and the decimal, binary, octal and hex fields never updated.

In `setupBitConvertor`, the BCD keyup handler decodes the nibbles into `num` and then calls:

```js
return setBaseValues(x);
```

There is no `x` in that scope. The three other handlers in the same function each declare their own local `x`, so this reads as a copy of one of them where the variable name was not updated. The decoded value in `num` was discarded and the reference threw.

The fix passes `num`:

```diff
-    return setBaseValues(x);
+    return setBaseValues(num);
```

Entering `00100101` now sets decimal to 25, hex to `0x19`, binary to `0b11001` and octal to `031`.

### Screenshots of the UI changes (If any) -

No layout change. The BCD field simply updates the other fields now instead of throwing.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The handler already did the real work correctly. It left-pads the input so its length is a multiple of four, walks it four bits at a time, rejects any nibble that decodes to 10 or more since those are not valid BCD digits, and otherwise accumulates the digit into `num` with `num * 10 + nibble`. The only defect was the final line handing `setBaseValues` a variable that does not exist, so the one-word change is the whole fix.

I considered rewriting the handler to share a decode helper with the other three fields, but they each parse a different base with a one-line `parseInt`, whereas BCD needs the nibble walk, so there is not much genuinely shared. Keeping the change to the broken line also keeps it easy to review against the reported error.

One thing I deliberately left alone: `if (input !== 0)` compares a string against the number `0`, so it is always true and the guard does nothing. It is harmless, since an empty input skips the loop and yields 0 anyway, and changing it would alter behaviour beyond the reported bug. Happy to clean it up separately if you would like.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

### Testing

The existing `spec/bitConvertor.spec.js` only asserted that `setupBitConvertor()` does not throw, which registers the handlers without ever running one, so the bug was invisible to it. Added two specs that actually fire `keyup` on the field:

- `00100101` updates all four other fields to 25 in their respective bases
- `1010` decodes to 10, which is not a valid BCD digit, so the fields keep their previous value

Both pass. Reverting `utils.ts` while keeping the specs reproduces `ReferenceError: x is not defined` in the first one, so it covers the change rather than restating current behaviour. The full suite (`vitest run --project src`) passes at 69 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected BCD input handling so valid values accurately update decimal, hexadecimal, binary, octal, and normalized BCD displays.
  * Invalid BCD digits no longer overwrite previously displayed values.
  * Clearing the BCD input now preserves the existing converted values instead of resetting them.

* **Tests**
  * Added coverage for valid BCD conversions, cleared input behavior, and invalid BCD input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->