### PR TITLE
fix(bit-converter): pad each BCD digit to a full 4 bit group

### DIFF
--- a/src/simulator/spec/bitConvertor.spec.js
+++ b/src/simulator/spec/bitConvertor.spec.js
@@ -98,12 +98,16 @@ describe('data dir working', () => {
     });
 
     test('dec2bcd output survives the 4 bit group round trip', () => {
-        for (const value of [0, 5, 9, 10, 25, 90, 255, 1000]) {
+        for (const value of [0, 5, 9, 10, 15, 25, 90, 255, 1000]) {
             const bcd = convertors.dec2bcd(value);
             expect(bcd.length % 4).toBe(0);
             let parsed = 0;
             for (let i = 0; i < bcd.length / 4; i++) {
-                parsed = parsed * 10 + parseInt(bcd.slice(4 * i, 4 * (i + 1)), 2);
+                const group = parseInt(bcd.slice(4 * i, 4 * (i + 1)), 2);
+                // Every group must be a valid BCD digit, not just sum back
+                // to the input, so 15 may never encode as a raw 1111 nibble.
+                expect(group).toBeLessThan(10);
+                parsed = parsed * 10 + group;
             }
             expect(parsed).toBe(value);
         }

--- a/src/simulator/spec/bitConvertor.spec.js
+++ b/src/simulator/spec/bitConvertor.spec.js
@@ -86,10 +86,9 @@ describe('data dir working', () => {
         expect(() => setBaseValues(randomBaseValue)).not.toThrow();
     });
     test('dec2bcd pads every decimal digit to a 4 bit group', () => {
-        // Each decimal digit is one nibble in BCD, so the first digit keeps
-        // its leading zeros. The old implementation dropped them, and the
-        // keyup parser, which reads 4 bit groups from the left, turned a
-        // displayed 25 back into 91. Matches convertToBCD in HexBinDec.vue.
+        // Each decimal digit is one nibble in BCD, so the leading digit keeps
+        // its zeros. The old implementation dropped them, which is not
+        // canonical BCD and disagrees with convertToBCD in HexBinDec.vue.
         expect(convertors.dec2bcd(0)).toBe('0000');
         expect(convertors.dec2bcd(9)).toBe('1001');
         expect(convertors.dec2bcd(10)).toBe('00010000');
@@ -98,7 +97,10 @@ describe('data dir working', () => {
     });
 
     test('dec2bcd output survives the 4 bit group round trip', () => {
-        for (const value of [0, 5, 9, 10, 15, 25, 90, 255, 1000]) {
+        // 99999999999999 is the important one: at 14 decimal digits the old
+        // parseInt(x.toString(10), 16) exceeded MAX_SAFE_INTEGER and rounded,
+        // so the value came back as 99999999999998.
+        for (const value of [0, 5, 9, 10, 15, 25, 90, 255, 1000, 99999999999999]) {
             const bcd = convertors.dec2bcd(value);
             expect(bcd.length % 4).toBe(0);
             let parsed = 0;

--- a/src/simulator/spec/bitConvertor.spec.js
+++ b/src/simulator/spec/bitConvertor.spec.js
@@ -1,5 +1,5 @@
 import { setup } from '../src/setup';
-import { bitConverterDialog, setBaseValues, setupBitConvertor } from '../src/utils';
+import { bitConverterDialog, convertors, setBaseValues, setupBitConvertor } from '../src/utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { mount } from '@vue/test-utils';
 import { createRouter, createWebHistory } from 'vue-router';
@@ -85,4 +85,28 @@ describe('data dir working', () => {
         console.log('Testing for Base Value --> ', randomBaseValue);
         expect(() => setBaseValues(randomBaseValue)).not.toThrow();
     });
+    test('dec2bcd pads every decimal digit to a 4 bit group', () => {
+        // Each decimal digit is one nibble in BCD, so the first digit keeps
+        // its leading zeros. The old implementation dropped them, and the
+        // keyup parser, which reads 4 bit groups from the left, turned a
+        // displayed 25 back into 91. Matches convertToBCD in HexBinDec.vue.
+        expect(convertors.dec2bcd(0)).toBe('0000');
+        expect(convertors.dec2bcd(9)).toBe('1001');
+        expect(convertors.dec2bcd(10)).toBe('00010000');
+        expect(convertors.dec2bcd(25)).toBe('00100101');
+        expect(convertors.dec2bcd(90)).toBe('10010000');
+    });
+
+    test('dec2bcd output survives the 4 bit group round trip', () => {
+        for (const value of [0, 5, 9, 10, 25, 90, 255, 1000]) {
+            const bcd = convertors.dec2bcd(value);
+            expect(bcd.length % 4).toBe(0);
+            let parsed = 0;
+            for (let i = 0; i < bcd.length / 4; i++) {
+                parsed = parsed * 10 + parseInt(bcd.slice(4 * i, 4 * (i + 1)), 2);
+            }
+            expect(parsed).toBe(value);
+        }
+    });
 });
+

--- a/src/simulator/src/utils.ts
+++ b/src/simulator/src/utils.ts
@@ -240,7 +240,16 @@ export const convertors = {
   dec2bin: (x: number) => "0b" + x.toString(2),
   dec2hex: (x: number) => "0x" + x.toString(16),
   dec2octal: (x: number) => "0" + x.toString(8),
-  dec2bcd: (x: number) => parseInt(x.toString(10), 16).toString(2),
+  // Encode each decimal digit as a 4 bit group. The old parseInt(x, 16) trick
+  // produced the right bits but dropped the first nibble's leading zeros, so
+  // 25 rendered as 100101 and the keyup parser, which reads 4 bit groups from
+  // the left, turned it back into 91. Matches convertToBCD in HexBinDec.vue.
+  dec2bcd: (x: number) =>
+    x
+      .toString(10)
+      .split("")
+      .map((digit) => parseInt(digit, 10).toString(2).padStart(4, "0"))
+      .join(""),
 };
 
 export function setBaseValues(x) {

--- a/src/simulator/src/utils.ts
+++ b/src/simulator/src/utils.ts
@@ -240,10 +240,12 @@ export const convertors = {
   dec2bin: (x: number) => "0b" + x.toString(2),
   dec2hex: (x: number) => "0x" + x.toString(16),
   dec2octal: (x: number) => "0" + x.toString(8),
-  // Encode each decimal digit as a 4 bit group. The old parseInt(x, 16) trick
-  // produced the right bits but dropped the first nibble's leading zeros, so
-  // 25 rendered as 100101 and the keyup parser, which reads 4 bit groups from
-  // the left, turned it back into 91. Matches convertToBCD in HexBinDec.vue.
+  // Encode each decimal digit as its own 4 bit group. The old
+  // parseInt(x.toString(10), 16) routed the value through a Number, so past 13
+  // decimal digits it exceeded MAX_SAFE_INTEGER and silently corrupted the
+  // result (99999999999999 came back as 99999999999998). Building the nibbles
+  // from the digit characters is exact at any length, emits canonical BCD with
+  // one nibble per digit, and matches convertToBCD in HexBinDec.vue.
   dec2bcd: (x: number) =>
     x
       .toString(10)

--- a/v1/src/simulator/spec/bitConvertor.spec.js
+++ b/v1/src/simulator/spec/bitConvertor.spec.js
@@ -98,12 +98,16 @@ describe('data dir working', () => {
     });
 
     test('dec2bcd output survives the 4 bit group round trip', () => {
-        for (const value of [0, 5, 9, 10, 25, 90, 255, 1000]) {
+        for (const value of [0, 5, 9, 10, 15, 25, 90, 255, 1000]) {
             const bcd = convertors.dec2bcd(value);
             expect(bcd.length % 4).toBe(0);
             let parsed = 0;
             for (let i = 0; i < bcd.length / 4; i++) {
-                parsed = parsed * 10 + parseInt(bcd.slice(4 * i, 4 * (i + 1)), 2);
+                const group = parseInt(bcd.slice(4 * i, 4 * (i + 1)), 2);
+                // Every group must be a valid BCD digit, not just sum back
+                // to the input, so 15 may never encode as a raw 1111 nibble.
+                expect(group).toBeLessThan(10);
+                parsed = parsed * 10 + group;
             }
             expect(parsed).toBe(value);
         }

--- a/v1/src/simulator/spec/bitConvertor.spec.js
+++ b/v1/src/simulator/spec/bitConvertor.spec.js
@@ -86,10 +86,9 @@ describe('data dir working', () => {
         expect(() => setBaseValues(randomBaseValue)).not.toThrow();
     });
     test('dec2bcd pads every decimal digit to a 4 bit group', () => {
-        // Each decimal digit is one nibble in BCD, so the first digit keeps
-        // its leading zeros. The old implementation dropped them, and the
-        // keyup parser, which reads 4 bit groups from the left, turned a
-        // displayed 25 back into 91. Matches convertToBCD in HexBinDec.vue.
+        // Each decimal digit is one nibble in BCD, so the leading digit keeps
+        // its zeros. The old implementation dropped them, which is not
+        // canonical BCD and disagrees with convertToBCD in HexBinDec.vue.
         expect(convertors.dec2bcd(0)).toBe('0000');
         expect(convertors.dec2bcd(9)).toBe('1001');
         expect(convertors.dec2bcd(10)).toBe('00010000');
@@ -98,7 +97,10 @@ describe('data dir working', () => {
     });
 
     test('dec2bcd output survives the 4 bit group round trip', () => {
-        for (const value of [0, 5, 9, 10, 15, 25, 90, 255, 1000]) {
+        // 99999999999999 is the important one: at 14 decimal digits the old
+        // parseInt(x.toString(10), 16) exceeded MAX_SAFE_INTEGER and rounded,
+        // so the value came back as 99999999999998.
+        for (const value of [0, 5, 9, 10, 15, 25, 90, 255, 1000, 99999999999999]) {
             const bcd = convertors.dec2bcd(value);
             expect(bcd.length % 4).toBe(0);
             let parsed = 0;

--- a/v1/src/simulator/spec/bitConvertor.spec.js
+++ b/v1/src/simulator/spec/bitConvertor.spec.js
@@ -1,5 +1,5 @@
 import { setup } from '../src/setup';
-import { bitConverterDialog, setBaseValues, setupBitConvertor } from '../src/utils';
+import { bitConverterDialog, convertors, setBaseValues, setupBitConvertor } from '../src/utils';
 import { createPinia, setActivePinia } from 'pinia';
 import { mount } from '@vue/test-utils';
 import { createRouter, createWebHistory } from 'vue-router';
@@ -85,4 +85,28 @@ describe('data dir working', () => {
         console.log('Testing for Base Value --> ', randomBaseValue);
         expect(() => setBaseValues(randomBaseValue)).not.toThrow();
     });
+    test('dec2bcd pads every decimal digit to a 4 bit group', () => {
+        // Each decimal digit is one nibble in BCD, so the first digit keeps
+        // its leading zeros. The old implementation dropped them, and the
+        // keyup parser, which reads 4 bit groups from the left, turned a
+        // displayed 25 back into 91. Matches convertToBCD in HexBinDec.vue.
+        expect(convertors.dec2bcd(0)).toBe('0000');
+        expect(convertors.dec2bcd(9)).toBe('1001');
+        expect(convertors.dec2bcd(10)).toBe('00010000');
+        expect(convertors.dec2bcd(25)).toBe('00100101');
+        expect(convertors.dec2bcd(90)).toBe('10010000');
+    });
+
+    test('dec2bcd output survives the 4 bit group round trip', () => {
+        for (const value of [0, 5, 9, 10, 25, 90, 255, 1000]) {
+            const bcd = convertors.dec2bcd(value);
+            expect(bcd.length % 4).toBe(0);
+            let parsed = 0;
+            for (let i = 0; i < bcd.length / 4; i++) {
+                parsed = parsed * 10 + parseInt(bcd.slice(4 * i, 4 * (i + 1)), 2);
+            }
+            expect(parsed).toBe(value);
+        }
+    });
 });
+

--- a/v1/src/simulator/src/utils.ts
+++ b/v1/src/simulator/src/utils.ts
@@ -240,7 +240,16 @@ export const convertors = {
   dec2bin: (x: number) => "0b" + x.toString(2),
   dec2hex: (x: number) => "0x" + x.toString(16),
   dec2octal: (x: number) => "0" + x.toString(8),
-  dec2bcd: (x: number) => parseInt(x.toString(10), 16).toString(2),
+  // Encode each decimal digit as a 4 bit group. The old parseInt(x, 16) trick
+  // produced the right bits but dropped the first nibble's leading zeros, so
+  // 25 rendered as 100101 and the keyup parser, which reads 4 bit groups from
+  // the left, turned it back into 91. Matches convertToBCD in HexBinDec.vue.
+  dec2bcd: (x: number) =>
+    x
+      .toString(10)
+      .split("")
+      .map((digit) => parseInt(digit, 10).toString(2).padStart(4, "0"))
+      .join(""),
 };
 
 export function setBaseValues(x) {

--- a/v1/src/simulator/src/utils.ts
+++ b/v1/src/simulator/src/utils.ts
@@ -240,10 +240,12 @@ export const convertors = {
   dec2bin: (x: number) => "0b" + x.toString(2),
   dec2hex: (x: number) => "0x" + x.toString(16),
   dec2octal: (x: number) => "0" + x.toString(8),
-  // Encode each decimal digit as a 4 bit group. The old parseInt(x, 16) trick
-  // produced the right bits but dropped the first nibble's leading zeros, so
-  // 25 rendered as 100101 and the keyup parser, which reads 4 bit groups from
-  // the left, turned it back into 91. Matches convertToBCD in HexBinDec.vue.
+  // Encode each decimal digit as its own 4 bit group. The old
+  // parseInt(x.toString(10), 16) routed the value through a Number, so past 13
+  // decimal digits it exceeded MAX_SAFE_INTEGER and silently corrupted the
+  // result (99999999999999 came back as 99999999999998). Building the nibbles
+  // from the digit characters is exact at any length, emits canonical BCD with
+  // one nibble per digit, and matches convertToBCD in HexBinDec.vue.
   dec2bcd: (x: number) =>
     x
       .toString(10)


### PR DESCRIPTION
### What

`dec2bcd` in `src/simulator/src/utils.ts` (and the byte-identical `v1` copy) is:

```ts
dec2bcd: (x: number) => parseInt(x.toString(10), 16).toString(2),
```

It routes the value through a `Number`, so past 13 decimal digits it exceeds `MAX_SAFE_INTEGER` and silently corrupts the output. It also drops the leading digit's zeros, so 25 renders as `100101` rather than the canonical `00100101`.

### Why it matters

The overflow is the real defect. Parsing the output back the way the `bcdInput` keyup handler does:

```
9999999999999    13 digits  old -> 9999999999999    ok
99999999999999   14 digits  old -> 99999999999998   corrupt
999999999999999  15 digits  old -> 999999999999980  corrupt
```

Every nibble in that 14 digit output is a valid BCD digit, so nothing rejects it; the value is just wrong.

Two smaller reasons on top of that:

1. `100101` is not canonical BCD for 25. Two decimal digits should be two nibbles.
2. It converges `utils.ts` with `convertToBCD` in `HexBinDec.vue`, which already pads with `padStart(4, '0')`.

**Correction to the original description.** I first claimed the unpadded output re-parsed as 91. That was wrong, and thanks to @Me-Priyank for catching it. Both BCD parsers left-pad to a multiple of 4 before reading groups (`while (input.length % 4 !== 0) input = '0' + input`, the only four `length % 4` sites in the tree), so the old short-value output round-tripped correctly:

```
x=25  old=100101 -> 25   new=00100101 -> 25
x=15  old=10101  -> 15   new=00010101 -> 15
```

The comment carrying that claim shipped in the source, so it has been rewritten in both trees along with the commit message.

### The change

Encode each decimal digit as its own 4 bit group from the digit characters, which is exact at any length, mirroring `HexBinDec.vue`, in both simulator trees.

### Verification

All 10 tests across both spec files pass. The round trip test now includes `99999999999999`, which fails on the old implementation with `parsed` coming back as `99999999999998` while every nibble is a valid BCD digit. Reverting only the two `utils.ts` files makes the new tests fail and leaves the pre-existing ones passing, so the new tests isolate the change.

Note on formatting: both spec files were already prettier-nonconforming on `main`, so I left the surrounding formatting alone rather than churn unrelated lines.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [x] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [x] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

Old code: dec2bcd: (x) => parseInt(x.toString(10), 16).toString(2)
It reads the decimal digits as if they were hex, producing a JavaScript Number
Past 13 digits that exceeds MAX_SAFE_INTEGER, so precision is silently lost: 99999999999999 round-trips back as 99999999999998, and 999999999999999 as 999999999999980
Secondary: it drops the leading digit's zeros, so 25 became 100101 instead of the canonical 00100101

Keep the hex trick but use BigInt to avoid the precision loss. Rejected: heavier, and still emits non-canonical BCD with the leading zeros stripped.
Fix only the padding. Rejected: leaves the overflow, which is the actual defect.

Working on the digit characters never builds a large number at all, so it stays exact at any length
It produces canonical BCD, one nibble per decimal digit
It matches convertToBCD in HexBinDec.vue, so the two dialogs agree instead of diverging


Key components

toString(10) for the digits, split("") per digit, parseInt(digit, 10).toString(2).padStart(4, "0") for each 4-bit group, join("") to concatenate
Same change applied to the v1 copy, since both trees carry the function
Tests: the round-trip test now includes 99999999999999, which fails on the old implementation with every nibble still a valid BCD digit and only the value wrong


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected decimal-to-BCD conversion so every digit is represented by a complete 4-bit group, preserving leading zeros.
  - Prevented BCD values from being misread when converted back into decimal values.

- **Tests**
  - Added coverage for padded BCD output and round-trip conversion across multiple values, including large numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
