### PR TITLE
fix: restrict draggable panels from moving beyond top navbar header

### DIFF
--- a/src/simulator/src/drag.ts
+++ b/src/simulator/src/drag.ts
@@ -67,10 +67,10 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
             document.querySelector(".header");
           const topOffset = navbar ? navbar.getBoundingClientRect().bottom : 46;
           return {
-            top: topOffset,
-            left: 0,
-            bottom: window.innerHeight,
-            right: window.innerWidth,
+            top: topOffset + window.scrollY,
+            left: window.scrollX,
+            bottom: window.innerHeight + window.scrollY,
+            right: window.innerWidth + window.scrollX,
           };
         },
       }),

--- a/src/simulator/src/drag.ts
+++ b/src/simulator/src/drag.ts
@@ -58,11 +58,21 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
         updatePosition(event.target as HTMLElement, event.dx, event.dy, positions);
       },
     },
-    // Set up modifiers to apply constraints to the draggable element
     modifiers: [
       interact.modifiers.restrictRect({
-        // Restrict the draggable element within its parent container
-        restriction: "body",
+        restriction: () => {
+          const navbar =
+            document.querySelector(".navbar") ||
+            document.querySelector("nav") ||
+            document.querySelector(".header");
+          const topOffset = navbar ? navbar.getBoundingClientRect().bottom : 46;
+          return {
+            top: topOffset,
+            left: 0,
+            bottom: window.innerHeight,
+            right: window.innerWidth,
+          };
+        },
       }),
     ],
   });

--- a/v1/src/simulator/src/drag.ts
+++ b/v1/src/simulator/src/drag.ts
@@ -67,10 +67,10 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
             document.querySelector(".header");
           const topOffset = navbar ? navbar.getBoundingClientRect().bottom : 46;
           return {
-            top: topOffset,
-            left: 0,
-            bottom: window.innerHeight,
-            right: window.innerWidth,
+            top: topOffset + window.scrollY,
+            left: window.scrollX,
+            bottom: window.innerHeight + window.scrollY,
+            right: window.innerWidth + window.scrollX,
           };
         },
       }),

--- a/v1/src/simulator/src/drag.ts
+++ b/v1/src/simulator/src/drag.ts
@@ -58,11 +58,21 @@ export function dragging(targetEl: HTMLElement, DragEl: HTMLElement): void {
         updatePosition(event.target as HTMLElement, event.dx, event.dy, positions);
       },
     },
-    // Set up modifiers to apply constraints to the draggable element
     modifiers: [
       interact.modifiers.restrictRect({
-        // Restrict the draggable element within its parent container
-        restriction: "body",
+        restriction: () => {
+          const navbar =
+            document.querySelector(".navbar") ||
+            document.querySelector("nav") ||
+            document.querySelector(".header");
+          const topOffset = navbar ? navbar.getBoundingClientRect().bottom : 46;
+          return {
+            top: topOffset,
+            left: 0,
+            bottom: window.innerHeight,
+            right: window.innerWidth,
+          };
+        },
       }),
     ],
   });


### PR DESCRIPTION
Fixes #1257 

#### Describe the changes you have made in this PR -
Updated drag restrictions for all draggable panels in both v0 (src/simulator/src/drag.ts) and v1 (v1/src/simulator/src/drag.ts).
Changed interact.modifiers.restrictRect constraint from "body" to a dynamic function calculating the bottom edge of the top navbar (navbar.getBoundingClientRect().bottom).
Prevented panel headers from sliding underneath/behind the top black navbar header when dragged upward.

Video Clip:
Before
[Screencast From 2026-09-04 21-35-58.webm](https://github.com/user-attachments/assets/ebe3e7b4-7296-4cb5-b88d-1db7a1a56d65)

After
[Screencast From 2026-09-04 22-00-31.webm](https://github.com/user-attachments/assets/8907aaac-1925-4213-98a4-d0f11941a448)

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
What problem does your code solve?: When users dragged panels (like Circuit Elements or Properties) to the top of the screen, the panel headers slid underneath the black navbar. Once underneath, users could no longer click or drag the panel handle to bring it back down.

What alternative approaches did you consider?:
Increasing panel z-index higher than navbar: Rejected because panels would cover the main navigation menu links.
Static top offset like 46px: Rejected because navbar height can vary on different screens and devices.

Why did you choose this specific implementation?: Using a dynamic function inside interact.modifiers.restrictRect reads the exact bottom position of the navbar (navbar.getBoundingClientRect().bottom) during drag events. This ensures panels stop right below the navbar on all screen sizes.

What are the key functions/components and what do they do?:
dragging() in src/simulator/src/drag.ts and v1/src/simulator/src/drag.ts: Initializes interact.js dragging behavior with the updated restrictRect top boundary modifier.

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag-and-drop boundaries so items remain within the visible viewport.
  - Prevented draggable items from moving behind the navigation header.
  - Added a fallback top boundary when no navigation header is detected.
  - Kept drag restrictions aligned with the page when users scroll horizontally or vertically.
  - Adjusted the boundaries dynamically to match the current window dimensions for more reliable dragging across different screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->