### PR TITLE
fix(ui): dynamic panel offset and z-index for expanded circuit tabs 

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -5,7 +5,7 @@
     position: relative;
     top: 0;
     width: 100%;
-    z-index: 100;
+    z-index: 1000;
 }
 .header {
     background: var(--bg-navbar);

--- a/src/components/Navbar/QuickButton/QuickButton.vue
+++ b/src/components/Navbar/QuickButton/QuickButton.vue
@@ -124,10 +124,11 @@ function dragover(): void {
     position: absolute;
     width: 400px;
     height: 33px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 280px;
     border-radius: 7px;
     z-index: 100;
+    transition: top 0.2s ease-in-out;
 }
 
 .quick-btn > div {

--- a/src/components/Navbar/User/User.scss
+++ b/src/components/Navbar/User/User.scss
@@ -2,6 +2,7 @@
   background: rgba(0, 0, 0, 0.8) !important;
   backdrop-filter: blur(10px);
   color: white !important;
+  z-index: 1050 !important;
 }
 
 .userMenu .v-list-item {

--- a/src/components/Navbar/User/UserMenu.vue
+++ b/src/components/Navbar/User/UserMenu.vue
@@ -1,28 +1,29 @@
 <template>
   <v-card class="avatar-menu" flat>
     <v-layout>
-      <v-navigation-drawer
-        v-model="drawer"
-        location="right"
-        class="userMenu"
-        temporary
-        width="270"
-      >
-        <div class="close-parent">
-          <v-btn
-            size="x-small"
-            icon
-            class="dialogClose"
-            @click="drawer = false"
-            variant="text"
-            color="white"
-          >
-            <v-icon icon="mdi-close" size="large"></v-icon>
-          </v-btn>
-        </div>
+      <teleport to="body">
+        <v-navigation-drawer
+          v-model="drawer"
+          location="right"
+          class="userMenu"
+          temporary
+          width="270"
+        >
+          <div class="close-parent">
+            <v-btn
+              size="x-small"
+              icon
+              class="dialogClose"
+              @click="drawer = false"
+              variant="text"
+              color="white"
+            >
+              <v-icon icon="mdi-close" size="large"></v-icon>
+            </v-btn>
+          </div>
 
-        <v-list-item
-          class="list-item-avatar"
+          <v-list-item
+            class="list-item-avatar"
           :prepend-avatar="authStore.getUserAvatar === 'default' ? undefined : authStore.getUserAvatar"
           :prepend-icon="
             authStore.getUserAvatar === 'default' ? 'mdi-account-circle-outline' : undefined
@@ -114,6 +115,7 @@
           ></v-list-item>
         </template>
       </v-navigation-drawer>
+      </teleport>
 
       <v-main>
         <v-btn

--- a/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
+++ b/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
@@ -88,7 +88,8 @@ function getImgUrl(elementName: string) {
   width: 220px;
   font: inherit;
   display: none;
-  top: 90px;
+  top: calc(var(--tabs-height, 30px) + 60px);
   left: 10px;
+  transition: top 0.2s ease-in-out;
 }
 </style>

--- a/src/components/TabsBar/TabsBar.vue
+++ b/src/components/TabsBar/TabsBar.vue
@@ -68,7 +68,7 @@
 <script lang="ts" setup>
 import draggable from 'vuedraggable'
 import { showMessage, truncateString } from '#/simulator/src/utils'
-import { ref, Ref } from 'vue'
+import { ref, Ref, onMounted, onUnmounted, nextTick } from 'vue'
 import {
     createNewCircuitScope,
     // deleteCurrentCircuit,
@@ -87,9 +87,46 @@ const updateCount: Ref<number> = ref(0)
 
 const showMaxHeight = ref(false)
 
+let resizeObserver: ResizeObserver | null = null
+
+function updateTabsHeight() {
+    const tabsBarEl = document.getElementById('tabsBar')
+    if (tabsBarEl) {
+        const height = tabsBarEl.offsetHeight
+        if (height > 0) {
+            document.documentElement.style.setProperty('--tabs-height', `${height}px`)
+        }
+    }
+}
+
 function toggleHeight() {
     showMaxHeight.value = !showMaxHeight.value
+    nextTick(() => {
+        updateTabsHeight()
+    })
 }
+
+onMounted(() => {
+    updateTabsHeight()
+    const tabsBarEl = document.getElementById('tabsBar')
+    if (tabsBarEl && typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const height = entry.borderBoxSize?.[0]?.blockSize ?? tabsBarEl.offsetHeight
+                if (height > 0) {
+                    document.documentElement.style.setProperty('--tabs-height', `${height}px`)
+                }
+            }
+        })
+        resizeObserver.observe(tabsBarEl)
+    }
+})
+
+onUnmounted(() => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+    document.documentElement.style.removeProperty('--tabs-height')
+})
 
 // const persistentShow: Ref<boolean> = ref(false)
 // const messageVal: Ref<string> = ref('')

--- a/src/styles/css/5-layout/simulator.scss
+++ b/src/styles/css/5-layout/simulator.scss
@@ -40,10 +40,11 @@
 
 #restrictedElementsDiv {
     position: absolute;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 10px;
     z-index: 100;
     width: 200px;
+    transition: top 0.2s ease-in-out;
 }
 
 #MessageDiv {

--- a/src/styles/css/UX.css
+++ b/src/styles/css/UX.css
@@ -395,10 +395,11 @@ html {
 
 #restrictedElementsDiv {
     position: absolute;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 10px;
     z-index: 100;
     width: 200px;
+    transition: top 0.2s ease-in-out;
 }
 
 #MessageDiv {

--- a/src/styles/css/main.stylesheet.css
+++ b/src/styles/css/main.stylesheet.css
@@ -358,8 +358,9 @@ input[type='text']:focus {
 .ce-panel {
     font: inherit;
     width: 240px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     left: 10px;
+    transition: top 0.2s ease-in-out;
 }
 
 .accordion > :last-child {
@@ -578,7 +579,7 @@ div.icon img {
     /* height: 23.5px; */
     display: block;
     align-items: center;
-    z-index: 99;
+    z-index: 1;
     /* position: absolute;
     top: 47px; */
 }
@@ -657,18 +658,19 @@ div.icon img {
 .moduleProperty {
     font: inherit;
     width: 250px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 10px;
+    transition: top 0.2s ease-in-out;
 }
 
 .timing-diagram-panel {
     border-radius: 5px;
     z-index: 70;
-    transition: background 0.5s ease-out;
+    transition: background 0.5s ease-out, top 0.2s ease-in-out;
     position: fixed;
     cursor: pointer;
     left: 300px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
 }
 
 .timing-diagram-panel .panel-header {
@@ -687,11 +689,11 @@ div.icon img {
 .testbench-manual-panel {
     border-radius: 5px;
     z-index: 100;
-    transition: background 0.5s ease-out;
+    transition: background 0.5s ease-out, top 0.2s ease-in-out;
     position: fixed;
     cursor: pointer;
     right: 10px;
-    top: 550px;
+    top: calc(var(--tabs-height, 30px) + 520px);
 }
 
 .testbench-manual-panel .panel-header {
@@ -883,8 +885,9 @@ div.icon img {
     width: 220px;
     font: inherit;
     display: none;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 300px;
+    transition: top 0.2s ease-in-out;
 }
 
 #moduleProperty-toolTip {
@@ -1101,8 +1104,9 @@ input:checked + .slider:before {
 #layoutDialog {
     /* display: none; */
     right: 10px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     width: 220px;
+    transition: top 0.2s ease-in-out;
 }
 
 .layout-title span {

--- a/v1/src/components/Navbar/Navbar.css
+++ b/v1/src/components/Navbar/Navbar.css
@@ -5,7 +5,7 @@
     position: relative;
     top: 0;
     width: 100%;
-    z-index: 100;
+    z-index: 1000;
 }
 .header {
     background: var(--bg-navbar);

--- a/v1/src/components/Navbar/QuickButton/QuickButton.vue
+++ b/v1/src/components/Navbar/QuickButton/QuickButton.vue
@@ -107,10 +107,11 @@ function dragover(): void {
   position: absolute;
   width: 400px;
   height: 33px;
-  top: 90px;
+  top: calc(var(--tabs-height, 30px) + 60px);
   right: 280px;
   border-radius: 7px;
   z-index: 100;
+  transition: top 0.2s ease-in-out;
 }
 
 .quick-btn > div {

--- a/v1/src/components/Navbar/User/User.scss
+++ b/v1/src/components/Navbar/User/User.scss
@@ -2,6 +2,7 @@
   background: rgba(0, 0, 0, 0.8) !important;
   backdrop-filter: blur(10px);
   color: white !important;
+  z-index: 1050 !important;
 }
 
 .userMenu .v-list-item {

--- a/v1/src/components/Navbar/User/UserMenu.vue
+++ b/v1/src/components/Navbar/User/UserMenu.vue
@@ -1,28 +1,29 @@
 <template>
   <v-card class="avatar-menu" flat>
     <v-layout>
-      <v-navigation-drawer
-        v-model="drawer"
-        location="right"
-        class="userMenu"
-        temporary
-        width="270"
-      >
-        <div class="close-parent">
-          <v-btn
-            size="x-small"
-            icon
-            class="dialogClose"
-            @click="drawer = false"
-            variant="text"
-            color="white"
-          >
-            <v-icon icon="mdi-close" size="large"></v-icon>
-          </v-btn>
-        </div>
+      <teleport to="body">
+        <v-navigation-drawer
+          v-model="drawer"
+          location="right"
+          class="userMenu"
+          temporary
+          width="270"
+        >
+          <div class="close-parent">
+            <v-btn
+              size="x-small"
+              icon
+              class="dialogClose"
+              @click="drawer = false"
+              variant="text"
+              color="white"
+            >
+              <v-icon icon="mdi-close" size="large"></v-icon>
+            </v-btn>
+          </div>
 
-        <v-list-item
-          class="list-item-avatar"
+          <v-list-item
+            class="list-item-avatar"
           :prepend-avatar="authStore.getUserAvatar"
           :prepend-icon="
             authStore.getUserAvatar === 'default' ? 'mdi-account-circle-outline' : undefined
@@ -115,6 +116,7 @@
           ></v-list-item>
         </template>
       </v-navigation-drawer>
+      </teleport>
 
       <v-main>
         <v-btn

--- a/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
+++ b/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
@@ -88,7 +88,8 @@ function getImgUrl(elementName: string) {
   width: 220px;
   font: inherit;
   display: none;
-  top: 90px;
+  top: calc(var(--tabs-height, 30px) + 60px);
   left: 10px;
+  transition: top 0.2s ease-in-out;
 }
 </style>

--- a/v1/src/components/TabsBar/TabsBar.vue
+++ b/v1/src/components/TabsBar/TabsBar.vue
@@ -68,7 +68,7 @@
 <script lang="ts" setup>
 import draggable from 'vuedraggable'
 import { showMessage, truncateString } from '#/simulator/src/utils'
-import { ref, Ref } from 'vue'
+import { ref, Ref, onMounted, onUnmounted, nextTick } from 'vue'
 import {
     createNewCircuitScope,
     // deleteCurrentCircuit,
@@ -87,9 +87,46 @@ const updateCount: Ref<number> = ref(0)
 
 const showMaxHeight = ref(false)
 
+let resizeObserver: ResizeObserver | null = null
+
+function updateTabsHeight() {
+    const tabsBarEl = document.getElementById('tabsBar')
+    if (tabsBarEl) {
+        const height = tabsBarEl.offsetHeight
+        if (height > 0) {
+            document.documentElement.style.setProperty('--tabs-height', `${height}px`)
+        }
+    }
+}
+
 function toggleHeight() {
     showMaxHeight.value = !showMaxHeight.value
+    nextTick(() => {
+        updateTabsHeight()
+    })
 }
+
+onMounted(() => {
+    updateTabsHeight()
+    const tabsBarEl = document.getElementById('tabsBar')
+    if (tabsBarEl && typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                const height = entry.borderBoxSize?.[0]?.blockSize ?? tabsBarEl.offsetHeight
+                if (height > 0) {
+                    document.documentElement.style.setProperty('--tabs-height', `${height}px`)
+                }
+            }
+        })
+        resizeObserver.observe(tabsBarEl)
+    }
+})
+
+onUnmounted(() => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+    document.documentElement.style.removeProperty('--tabs-height')
+})
 
 // const persistentShow: Ref<boolean> = ref(false)
 // const messageVal: Ref<string> = ref('')

--- a/v1/src/styles/css/5-layout/simulator.scss
+++ b/v1/src/styles/css/5-layout/simulator.scss
@@ -40,10 +40,11 @@
 
 #restrictedElementsDiv {
     position: absolute;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 10px;
     z-index: 100;
     width: 200px;
+    transition: top 0.2s ease-in-out;
 }
 
 #MessageDiv {

--- a/v1/src/styles/css/UX.css
+++ b/v1/src/styles/css/UX.css
@@ -395,10 +395,11 @@ html {
 
 #restrictedElementsDiv {
     position: absolute;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 10px;
     z-index: 100;
     width: 200px;
+    transition: top 0.2s ease-in-out;
 }
 
 #MessageDiv {

--- a/v1/src/styles/css/main.stylesheet.css
+++ b/v1/src/styles/css/main.stylesheet.css
@@ -358,8 +358,9 @@ input[type='text']:focus {
 .ce-panel {
     font: inherit;
     width: 240px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     left: 10px;
+    transition: top 0.2s ease-in-out;
 }
 
 .accordion > :last-child {
@@ -578,7 +579,7 @@ div.icon img {
     /* height: 23.5px; */
     display: block;
     align-items: center;
-    z-index: 99;
+    z-index: 1;
     /* position: absolute;
     top: 47px; */
 }
@@ -657,18 +658,19 @@ div.icon img {
 .moduleProperty {
     font: inherit;
     width: 250px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 10px;
+    transition: top 0.2s ease-in-out;
 }
 
 .timing-diagram-panel {
     border-radius: 5px;
     z-index: 70;
-    transition: background 0.5s ease-out;
+    transition: background 0.5s ease-out, top 0.2s ease-in-out;
     position: fixed;
     cursor: pointer;
     left: 300px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
 }
 
 .timing-diagram-panel .panel-header {
@@ -687,11 +689,11 @@ div.icon img {
 .testbench-manual-panel {
     border-radius: 5px;
     z-index: 100;
-    transition: background 0.5s ease-out;
+    transition: background 0.5s ease-out, top 0.2s ease-in-out;
     position: fixed;
     cursor: pointer;
     right: 10px;
-    top: 550px;
+    top: calc(var(--tabs-height, 30px) + 520px);
 }
 
 .testbench-manual-panel .panel-header {
@@ -883,8 +885,9 @@ div.icon img {
     width: 220px;
     font: inherit;
     display: none;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     right: 300px;
+    transition: top 0.2s ease-in-out;
 }
 
 #moduleProperty-toolTip {
@@ -1101,8 +1104,9 @@ input:checked + .slider:before {
 #layoutDialog {
     /* display: none; */
     right: 10px;
-    top: 90px;
+    top: calc(var(--tabs-height, 30px) + 60px);
     width: 220px;
+    transition: top 0.2s ease-in-out;
 }
 
 .layout-title span {


### PR DESCRIPTION
Fixes #1275 

#### Describe the changes you have made in this PR -

Fixed an issue where circuit tabs could become overlapped by floating UI panels such as Circuit Elements, Timing Diagram, and Properties when multiple tabs were open.

When the tab bar overflowed and the right-side arrow button was used to reveal additional tabs, some tabs could appear underneath these floating sections, making them difficult or impossible to access.

This PR updates the tab positioning/layout behavior so that the tabs remain visible and accessible even when multiple tabs are opened and the overflow navigation is used.

The fix has been applied to both v0 and v1.

Video Clip
Before-
[Screencast From 2026-09-09 21-50-28.webm](https://github.com/user-attachments/assets/88588731-8839-414d-b07e-523535389c3f)

After-
[Screencast From 2026-09-09 22-33-45.webm](https://github.com/user-attachments/assets/02f2bc9b-38e8-487e-89cb-0e4df46129ba)


#### Code Understanding and AI Usage

**Did you use AI assistance to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [ ] I can explain the purpose and logic of each function/component I added
- [ ] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**

The issue was caused by the circuit tab area not properly accounting for the space occupied by the floating UI sections. As a result, when multiple tabs were created and the overflow navigation was used, some tabs could be rendered underneath the Circuit Elements, Timing Diagram, or Properties sections.
I adjusted the tab layout/positioning so that the tab bar remains within the accessible area and does not get hidden behind the floating panels.
The implementation was kept focused on the existing tab layout behavior rather than changing the functionality of the floating panels. This preserves the existing UI behavior while ensuring that overflowing tabs remain accessible.

#### Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [x] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interface layering so the navigation bar and user menu remain accessible above overlapping elements.
  * Updated floating panels and quick-access controls to adjust their position when the tab bar changes height.
  * Added smooth repositioning transitions to reduce visual jumps when interface elements move.
  * Improved user menu placement to prevent it from being constrained by surrounding layout elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->