### PR TITLE
feat(simulator): Move subcircuit dragend logic from `listeners.js` into `LayoutElementsPanel.vue`

### DIFF
--- a/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
+++ b/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
@@ -98,6 +98,9 @@ function onSubcircuitDragEnd(event: DragEvent) {
       SimulatorState.subCircuitElementList.filter((typeGroup) => typeGroup.elements.length > 0)
   }
 
+  // Clear newElement flag native drag suppresses mouseup on simulationArea,
+  // so the canvas never resets it. Must clear for both valid and cancelled drops.
+  if (draggingElement.value) draggingElement.value.newElement = false
   draggingElement.value = null
 }
 </script>

--- a/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
+++ b/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
@@ -18,8 +18,8 @@
               :key="`${groupIndex}-${elementIndex}`" :id="`${group.type}-${elementIndex}`"
               :data-element-id="elementIndex" :data-element-name="group.type"
               draggable="true"
-              @mousedown="dragElement(group.type, element, elementIndex)"
-              @dragend="onSubcircuitDragEnd($event, group.type, elementIndex)">
+              @mousedown="dragElement(element)"
+              @dragend="onSubcircuitDragEnd($event)">
               <div class="icon-image">
                 <img :src="getImgUrl(group.type)" />
                 <p class="img__description">
@@ -45,6 +45,7 @@ import { ref, onMounted } from 'vue';
 const layoutStore = useLayoutStore()
 
 const layoutElementPanelRef = ref<HTMLElement | null>(null);
+const draggingElement = ref<any>(null);
 
 onMounted(() => {
     layoutStore.layoutElementPanelRef = layoutElementPanelRef.value
@@ -52,28 +53,11 @@ onMounted(() => {
 
 const SimulatorState = useState();
 
-const dragElement = (groupType: string, element: any, index: number) => {
-  element.subcircuitMetadata.showInSubcircuit = true
+const dragElement = (element: any) => {
+  // Store reference; list removal deferred to @dragend (valid drop only)
   element.newElement = true
   simulationArea.lastSelected = element
-
-  // Remove the element from subCircuitElementList
-  SimulatorState.subCircuitElementList.forEach((typeGroup) => {
-    typeGroup.elements = typeGroup.elements.filter(
-      (_, elementIndex) => {
-        if(typeGroup.type === groupType && index === elementIndex)
-        return false
-
-        return true;
-      }
-    )
-  })
-
-  // Remove the type group if its elements array is empty
-  SimulatorState.subCircuitElementList =
-    SimulatorState.subCircuitElementList.filter(
-      (typeGroup) => typeGroup.elements.length > 0
-    )
+  draggingElement.value = element
 }
 
 function getImgUrl(elementName: string) {
@@ -84,7 +68,7 @@ function getImgUrl(elementName: string) {
   return elementImg;
 }
 
-function onSubcircuitDragEnd(event: DragEvent, elementName: string, elementId: number) {
+function onSubcircuitDragEnd(event: DragEvent) {
   const panelEl = layoutElementPanelRef.value
   const rect = panelEl?.getBoundingClientRect()
   const top = event.clientY - (rect?.top ?? 0)
@@ -93,9 +77,11 @@ function onSubcircuitDragEnd(event: DragEvent, elementName: string, elementId: n
   const sideBarWidth = document.getElementById('guide_1')?.clientWidth ?? 0
 
   if (top > 10 && left > sideBarWidth) {
-    const tempElement = globalScope[elementName][elementId]
+    const tempElement = draggingElement.value
     if (!tempElement) return
 
+    // Set showInSubcircuit here - deferred from mousedown, only on valid drop
+    tempElement.subcircuitMetadata.showInSubcircuit = true
     tempElement.x = left - sideBarWidth
     tempElement.y = top
     for (const node of tempElement.nodeList) {
@@ -104,15 +90,15 @@ function onSubcircuitDragEnd(event: DragEvent, elementName: string, elementId: n
     }
     tempBuffer.subElements.push(tempElement)
 
-    // Remove element from reactive list — Vue removes DOM node, no removeChild needed
+    // Remove by object identity - safe even if indices shifted
     SimulatorState.subCircuitElementList.forEach((typeGroup) => {
-      if (typeGroup.type === elementName) {
-        typeGroup.elements = typeGroup.elements.filter((_, index) => index !== elementId)
-      }
+      typeGroup.elements = typeGroup.elements.filter((el) => el !== tempElement)
     })
     SimulatorState.subCircuitElementList =
       SimulatorState.subCircuitElementList.filter((typeGroup) => typeGroup.elements.length > 0)
   }
+
+  draggingElement.value = null
 }
 </script>
 

--- a/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
+++ b/v1/src/components/Panels/LayoutElementsPanel/LayoutElementsPanel.vue
@@ -17,7 +17,9 @@
               <div v-for="(element, elementIndex) in group.elements" class="icon subcircuitModule"
               :key="`${groupIndex}-${elementIndex}`" :id="`${group.type}-${elementIndex}`"
               :data-element-id="elementIndex" :data-element-name="group.type"
-              @mousedown="dragElement(group.type, element, elementIndex)">
+              draggable="true"
+              @mousedown="dragElement(group.type, element, elementIndex)"
+              @dragend="onSubcircuitDragEnd($event, group.type, elementIndex)">
               <div class="icon-image">
                 <img :src="getImgUrl(group.type)" />
                 <p class="img__description">
@@ -37,6 +39,7 @@
 import { useState } from '#/store/SimulatorStore/state'
 import { simulationArea } from '#/simulator/src/simulationArea'
 import { useLayoutStore } from '#/store/layoutStore';
+import { tempBuffer } from '#/simulator/src/layoutMode';
 import { ref, onMounted } from 'vue';
 
 const layoutStore = useLayoutStore()
@@ -79,6 +82,37 @@ function getImgUrl(elementName: string) {
     import.meta.url
   ).href;
   return elementImg;
+}
+
+function onSubcircuitDragEnd(event: DragEvent, elementName: string, elementId: number) {
+  const panelEl = layoutElementPanelRef.value
+  const rect = panelEl?.getBoundingClientRect()
+  const top = event.clientY - (rect?.top ?? 0)
+  const left = event.clientX - (rect?.left ?? 0)
+
+  const sideBarWidth = document.getElementById('guide_1')?.clientWidth ?? 0
+
+  if (top > 10 && left > sideBarWidth) {
+    const tempElement = globalScope[elementName][elementId]
+    if (!tempElement) return
+
+    tempElement.x = left - sideBarWidth
+    tempElement.y = top
+    for (const node of tempElement.nodeList) {
+      node.x = left - sideBarWidth
+      node.y = top
+    }
+    tempBuffer.subElements.push(tempElement)
+
+    // Remove element from reactive list — Vue removes DOM node, no removeChild needed
+    SimulatorState.subCircuitElementList.forEach((typeGroup) => {
+      if (typeGroup.type === elementName) {
+        typeGroup.elements = typeGroup.elements.filter((_, index) => index !== elementId)
+      }
+    })
+    SimulatorState.subCircuitElementList =
+      SimulatorState.subCircuitElementList.filter((typeGroup) => typeGroup.elements.length > 0)
+  }
 }
 </script>
 

--- a/v1/src/simulator/src/listeners.js
+++ b/v1/src/simulator/src/listeners.js
@@ -9,7 +9,6 @@
 // Most Listeners are stored here
 import {
     layoutModeGet,
-    tempBuffer,
     layoutUpdate,
 } from './layoutMode'
 import { simulationArea } from './simulationArea'
@@ -674,29 +673,7 @@ export default function startListeners() {
             e.preventDefault()
         }
     })
-
-    // 'drag and drop' event listener for subcircuit elements in layout mode
-    $('#subcircuitMenu').on('dragstop', '.draggableSubcircuitElement', function (event, ui) {
-        const sideBarWidth = $('#guide_1')[0].clientWidth;
-        let tempElement;
-
-        if (ui.position.top > 10 && ui.position.left > sideBarWidth) {
-            // Make a shallow copy of the element with the new coordinates
-            tempElement = globalScope[this.dataset.elementName][this.dataset.elementId];
-            // Changing the coordinate doesn't work yet, nodes get far from element
-            tempElement.x = ui.position.left - sideBarWidth;
-            tempElement.y = ui.position.top;
-            for (const node of tempElement.nodeList) {
-                node.x = ui.position.left - sideBarWidth;
-                node.y = ui.position.top;
-            }
-
-            tempBuffer.subElements.push(tempElement);
-            this.parentElement.removeChild(this);
-        }
-    });
-
-    restrictedElements.forEach((element) => {
+restrictedElements.forEach((element) => {
         $(`#${element}`).mouseover(() => {
             showRestricted()
         })


### PR DESCRIPTION
Fixes a part of #1256

#### Describe the changes you have made in this PR -
- Removed the jQuery `dragstop` listener for `#subcircuitMenu` from `listeners.js`
- Added `draggable="true"` and a native `@dragend` handler (`onSubcircuitDragEnd`) to the existing `LayoutElementsPanel.vue` component
- The new handler replicates the old coordinate logic using `getBoundingClientRect()` instead of jQuery's `ui.position` — zero visible UI change
- Element removal from the panel now happens by filtering the reactive Pinia store array (`subCircuitElementList`) instead of using `this.parentElement.removeChild(this)` — Vue removes the DOM node declaratively
- Removed unused `tempBuffer` import from `listeners.js`
- Resolves step 4 of the #1256 implementation plan

### Screenshots of the UI changes (If any) -

**Before (main branch):**

https://github.com/user-attachments/assets/8e3b1502-adac-40dc-a23d-6c67626fd680



**After PR:**

https://github.com/user-attachments/assets/004401d0-8b2d-4bd0-9008-e781a5a61758


> Both videos show identical behavior , this is an internal architecture refactor. The drag-and-drop in Layout Mode works exactly the same; the jQuery `dragstop` listener was dead code replaced by a native Vue `@dragend` handler.

---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [ ] No, I wrote all the code myself
- [x] Yes, I used AI assistance (continue below)

**If you used AI assistance:**
- [ ] I have reviewed every single line of the AI-generated code
- [x] I can explain the purpose and logic of each function/component I added
- [x] I have tested edge cases and understand how the code handles them
- [ ] I have modified the AI output to follow this project's coding standards and conventions

**Explain your implementation approach:**
The old code used a jQuery `dragstop` event on `#subcircuitMenu` to detect when a subcircuit element was dropped onto the canvas, then manually updated its coordinates and called `this.parentElement.removeChild(this)` to remove it from the DOM. This directly violated Vue's declarative rendering model.

The chosen approach adds `draggable="true"` and `@dragend` to the `v-for` items already rendered in `LayoutElementsPanel.vue`. The new `onSubcircuitDragEnd` function replicates the coordinate math using `getBoundingClientRect()` on the panel container (equivalent to jQuery's `ui.position`), then removes the element from the reactive `subCircuitElementList` store array — letting Vue handle the DOM update automatically.

Alternative considered: creating a new `SubcircuitMenu.vue` component. Rejected because `LayoutElementsPanel.vue` already has the data and the `v-for` loop , no new component was needed.

I love watermelons!

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---

Note: Please check **Allow edits from maintainers** if you would like us to assist in the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Subcircuit elements can be dragged directly from the elements panel and placed in valid layout areas.
  - Dropped elements are positioned automatically and added to the current layout.

- **Bug Fixes**
  - Improved drag-and-drop handling during layout editing.
  - Elements remain available in the panel until a valid drop is completed.
  - Cancelled drops no longer leave elements in an incomplete drag state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->