### PR TITLE
fix: correct pinch zoom distance calculation

### DIFF
--- a/src/simulator/src/listeners.js
+++ b/src/simulator/src/listeners.js
@@ -147,7 +147,9 @@ export function pinchZoom(e, globalScope) {
     updatePositionSet(true);
     updateCanvasSet(true);
     // Calculating distance between touch to see if its pinchIN or pinchOut
-    distance = Math.sqrt((e.touches[1].clientX - e.touches[0].clientX) ** 2, (e.touches[1].clientY - e.touches[0].clientY) ** 2);
+    const dx = e.touches[1].clientX - e.touches[0].clientX;
+    const dy = e.touches[1].clientY - e.touches[0].clientY;
+    distance = Math.sqrt(dx ** 2 + dy ** 2);
     if (distance >= currDistance) {
         pinchZ += 0.02;
         currDistance = distance;


### PR DESCRIPTION
Fixes #1297


#### Describe the changes you have made in this PR -
- Corrected the pinch-zoom distance calculation in `pinchZoom()`.
- Calculate both horizontal (`dx`) and vertical (`dy`) distances between the two touch points.
- Use the Euclidean distance formula so both axes are considered.
- Kept the change minimal without modifying the existing pinch-zoom logic.
---

## Code Understanding and AI Usage

**Did you use AI assistance (ChatGPT, Claude, Copilot, etc.) to write any part of this code?**
- [x] No, I wrote all the code myself
- [ ] Yes, I used AI assistance (continue below)


**Explain your implementation approach:**

- The issue was caused by `Math.sqrt()` receiving `dx²` and `dy²` as separate arguments, so the vertical component was ignored.
- I fixed this by calculating `dx` and `dy` separately and using the Euclidean distance formula.
- I considered `Math.hypot(dx, dy)`, but chose the explicit calculation for clarity and consistency.
- The change is limited to `pinchZoom()` in `src/simulator/src/listeners.js` and does not alter the existing zoom logic.

---

## Checklist before requesting a review
- [x] I have added proper PR title and linked to the issue
- [x] I have performed a self-review of my code
- [x] **I can explain the purpose of every function, class, and logic block I added**
- [x] I understand why my changes work and have tested them thoroughly
- [x] I have considered potential edge cases and how my code handles them
- [ ] If it is a core feature, I have added thorough tests
- [x] My code follows the project's style guidelines and conventions

---





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pinch-to-zoom distance calculations for more accurate zoom behavior during touch gestures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->